### PR TITLE
Flickering mitigations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tracing = { git = "https://github.com/tokio-rs/tracing", rev = "b8c45cc" }
 tracing-subscriber = { git = "https://github.com/tokio-rs/tracing", rev = "b8c45cc", features = ["env-filter"] }
 tracing-appender = { git = "https://github.com/tokio-rs/tracing", rev = "b8c45cc" }
 smithay = { git = "https://github.com/Smithay/smithay", rev = "1a61e1c", features = ["desktop", "wayland_frontend"] }
-smithay-drm-extras = { git = "https://github.com/Smithay/smithay", optional = true }
+smithay-drm-extras = { git = "https://github.com/Smithay/smithay", rev = "1a61e1c", optional = true }
 thiserror = "1.0.48"
 xcursor = { version = "0.3.4", optional = true }
 image = { version = "0.24.7", default-features = false, optional = true }

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -1484,13 +1484,14 @@ fn render_surface<'a>(
         .iter()
         .filter(|win| win.alive())
         .filter(|win| {
-            if let WindowElement::Wayland(win) = win {
+            let pending_size = if let WindowElement::Wayland(win) = win {
                 let current_state = win.toplevel().current_state();
                 win.toplevel()
                     .with_pending_state(|state| state.size != current_state.size)
             } else {
                 false
-            }
+            };
+            pending_size || win.with_state(|state| !state.loc_request_state.is_idle())
         })
         .map(|win| {
             (

--- a/src/grab/move_grab.rs
+++ b/src/grab/move_grab.rs
@@ -86,6 +86,19 @@ impl PointerGrab<State> for MoveSurfaceGrab<State> {
                     return;
                 }
 
+                if state
+                    .space
+                    .element_geometry(&self.window)
+                    .is_some_and(|geo| {
+                        state
+                            .space
+                            .element_geometry(&window_under)
+                            .is_some_and(|geo2| geo.overlaps(geo2))
+                    })
+                {
+                    return;
+                }
+
                 let is_floating =
                     window_under.with_state(|state| state.floating_or_tiled.is_floating());
 
@@ -101,6 +114,7 @@ impl PointerGrab<State> for MoveSurfaceGrab<State> {
                     return;
                 }
 
+                tracing::debug!("Swapping window positions");
                 state.swap_window_positions(&self.window, &window_under);
             }
         } else {

--- a/src/render.rs
+++ b/src/render.rs
@@ -65,7 +65,6 @@ where
         scale: Scale<f64>,
         alpha: f32,
     ) -> Vec<C> {
-        // let window_bbox = self.bbox();
         match self {
             WindowElement::Wayland(window) => {
                 window.render_elements(renderer, location, scale, alpha)
@@ -112,7 +111,7 @@ where
         .map(|(surface, loc)| {
             let render_elements = surface.render_elements::<WaylandSurfaceRenderElement<R>>(
                 renderer,
-                loc.to_physical(1),
+                loc.to_physical((scale.x.round() as i32, scale.x.round() as i32)),
                 scale,
                 1.0,
             );


### PR DESCRIPTION
Alrighty I thought that I would need to change the rendering on udev but apparently the problem I've been seeing (jittery scrolling) doesn't happen in release mode, which tells me that I might be doing something that takes too long, because Anvil doesn't have this issue.

But hey there  are some flickering mitigations like cropping all windows to the expected size. <sup>not gonna lie it's kinda feeling like i'm slapping bandages on top of other bandages, maybe i'll get around to working in a system for atomic updates across all windows</sup>