### PR TITLE
Rewrite Rust API

### DIFF
--- a/api/rust_grpc/Cargo.toml
+++ b/api/rust_grpc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust_grpc"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/api/rust_grpc/src/lib.rs
+++ b/api/rust_grpc/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
1. To make it use gRPC
2. To make it more rusty

Closes #112 