### PR TITLE
Scaffold a signal system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,6 +1622,7 @@ dependencies = [
  "pinnacle-api-defs",
  "pinnacle-api-macros",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tower",
  "xkbcommon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/pinnacle-comp/pinnacle/"
 
 [workspace.dependencies]
 tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"]}
+tokio-stream = { version = "0.1.14", features = ["net"] }
 
 prost = "0.12.3"
 tonic = "0.11.0"
@@ -61,7 +62,7 @@ tonic = { workspace = true }
 tonic-reflection = { workspace = true }
 
 tokio = { workspace = true, features = ["process", "io-util", "signal"] }
-tokio-stream = { version = "0.1.14", features = ["net"] }
+tokio-stream = { workspace = true }
 
 bitflags = "2.4.2"
 pinnacle-api-defs = { workspace = true }

--- a/api/lua/pinnacle-api-dev-1.rockspec
+++ b/api/lua/pinnacle-api-dev-1.rockspec
@@ -26,5 +26,6 @@ build = {
         ["pinnacle.tag"] = "pinnacle/tag.lua",
         ["pinnacle.window"] = "pinnacle/window.lua",
         ["pinnacle.util"] = "pinnacle/util.lua",
+        ["pinnacle.signal"] = "pinnacle/signal.lua",
     },
 }

--- a/api/lua/pinnacle-api-dev-1.rockspec
+++ b/api/lua/pinnacle-api-dev-1.rockspec
@@ -24,6 +24,7 @@ build = {
         ["pinnacle.output"] = "pinnacle/output.lua",
         ["pinnacle.process"] = "pinnacle/process.lua",
         ["pinnacle.tag"] = "pinnacle/tag.lua",
+        ["pinnacle.tag.layout"] = "pinnacle/tag/layout.lua",
         ["pinnacle.window"] = "pinnacle/window.lua",
         ["pinnacle.util"] = "pinnacle/util.lua",
         ["pinnacle.signal"] = "pinnacle/signal.lua",

--- a/api/lua/pinnacle/grpc/client.lua
+++ b/api/lua/pinnacle/grpc/client.lua
@@ -42,6 +42,8 @@ end
 ---@field new_stream function
 
 ---@class H2Stream
+---@field write_chunk function
+---@field shutdown function
 
 ---@nodoc
 ---@class Client
@@ -202,8 +204,6 @@ function client.bidirectional_streaming_request(grpc_request_params, callback)
                 print(name, value, never_index)
             end
         end
-
-        print("AFTER bidirectional_streaming_request ENDS")
     end)
 
     return stream

--- a/api/lua/pinnacle/grpc/client.lua
+++ b/api/lua/pinnacle/grpc/client.lua
@@ -162,4 +162,10 @@ function client.server_streaming_request(grpc_request_params, callback)
     end)
 end
 
+---@param grpc_request_params GrpcRequestParams
+---@param callback fun(response: table)
+---
+---@return H2Stream
+function client.bidirectional_streaming_request(grpc_request_params, callback) end
+
 return client

--- a/api/lua/pinnacle/grpc/client.lua
+++ b/api/lua/pinnacle/grpc/client.lua
@@ -8,6 +8,7 @@ local h2_connection = require("http.h2_connection")
 local protobuf = require("pinnacle.grpc.protobuf")
 local pb = require("pb")
 
+---@nodoc
 ---Create appropriate headers for a gRPC request.
 ---@param service string The desired service
 ---@param method string The desired method within the service

--- a/api/lua/pinnacle/grpc/client.lua
+++ b/api/lua/pinnacle/grpc/client.lua
@@ -8,7 +8,6 @@ local h2_connection = require("http.h2_connection")
 local protobuf = require("pinnacle.grpc.protobuf")
 local pb = require("pb")
 
----@nodoc
 ---Create appropriate headers for a gRPC request.
 ---@param service string The desired service
 ---@param method string The desired method within the service
@@ -160,6 +159,7 @@ function client.server_streaming_request(grpc_request_params, callback)
     end)
 end
 
+---@nodoc
 ---@param grpc_request_params GrpcRequestParams
 ---@param callback fun(response: table)
 ---

--- a/api/lua/pinnacle/grpc/protobuf.lua
+++ b/api/lua/pinnacle/grpc/protobuf.lua
@@ -39,6 +39,7 @@ function protobuf.build_protos()
     pb.option("enum_as_value")
 end
 
+---@nodoc
 ---Encode the given `data` as the protobuf `type`.
 ---@param type string The absolute protobuf type
 ---@param data table The table of data, conforming to its protobuf definition

--- a/api/lua/pinnacle/grpc/protobuf.lua
+++ b/api/lua/pinnacle/grpc/protobuf.lua
@@ -17,6 +17,7 @@ function protobuf.build_protos()
         PINNACLE_PROTO_DIR .. "/pinnacle/output/" .. version .. "/output.proto",
         PINNACLE_PROTO_DIR .. "/pinnacle/process/" .. version .. "/process.proto",
         PINNACLE_PROTO_DIR .. "/pinnacle/window/" .. version .. "/window.proto",
+        PINNACLE_PROTO_DIR .. "/pinnacle/signal/" .. version .. "/signal.proto",
     }
 
     local cmd = "protoc --descriptor_set_out=/tmp/pinnacle.pb --proto_path=" .. PINNACLE_PROTO_DIR .. " "
@@ -36,6 +37,27 @@ function protobuf.build_protos()
     assert(pb.load(pinnacle_pb_data), "failed to load .pb file")
 
     pb.option("enum_as_value")
+end
+
+---Encode the given `data` as the protobuf `type`.
+---@param type string The absolute protobuf type
+---@param data table The table of data, conforming to its protobuf definition
+---@return string buffer The encoded buffer
+function protobuf.encode(type, data)
+    local success, obj = pcall(pb.encode, type, data)
+    if not success then
+        print("failed to encode:", obj, "type:", type)
+        os.exit(1)
+    end
+
+    local encoded_protobuf = obj
+
+    local packed_prefix = string.pack("I1", 0)
+    local payload_len = string.pack(">I4", encoded_protobuf:len())
+
+    local body = packed_prefix .. payload_len .. encoded_protobuf
+
+    return body
 end
 
 return protobuf

--- a/api/lua/pinnacle/output.lua
+++ b/api/lua/pinnacle/output.lua
@@ -164,6 +164,10 @@ function output.connect_for_all(callback)
     })
 end
 
+local signal_name_to_SignalName = {
+    connect = "OutputConnect",
+}
+
 ---@class OutputSignal
 ---@field connect fun(output: OutputHandle)?
 
@@ -174,12 +178,10 @@ function output.connect_signal(signals)
     local handles = require("pinnacle.signal").handles.new({})
 
     for signal, callback in pairs(signals) do
-        if signal == "connect" then
-            require("pinnacle.signal").add_callback("OutputConnect", callback)
-            ---@diagnostic disable-next-line: invisible
-            local handle = require("pinnacle.signal").handle.new("OutputConnect", callback)
-            handles[signal] = handle
-        end
+        require("pinnacle.signal").add_callback(signal_name_to_SignalName[signal], callback)
+        ---@diagnostic disable-next-line: invisible
+        local handle = require("pinnacle.signal").handle.new(signal_name_to_SignalName[signal], callback)
+        handles[signal] = handle
     end
 
     return handles

--- a/api/lua/pinnacle/output.lua
+++ b/api/lua/pinnacle/output.lua
@@ -168,11 +168,31 @@ local signal_name_to_SignalName = {
     connect = "OutputConnect",
 }
 
----@class OutputSignal
----@field connect fun(output: OutputHandle)?
+---@class OutputSignal Signals related to output events.
+---@field connect fun(output: OutputHandle)? An output was connected. FIXME: This currently does not fire for outputs that have been previously connected and disconnected.
 
----@param signals OutputSignal
----@return SignalHandles
+---Connect to an output signal.
+---
+---The compositor sends signals about various events. Use this function to run a callback when
+---some output signal occurs.
+---
+---This function returns a table of signal handles with each handle stored at the same key used
+---to connect to the signal. See `SignalHandles` for more information.
+---
+---# Example
+---```lua
+---Output.connect_signal({
+---    connect = function(output)
+---        print("New output connected:", output.name)
+---    end
+---})
+---```
+---
+---@param signals OutputSignal The signal you want to connect to
+---
+---@return SignalHandles signal_handles Handles to every signal you connected to wrapped in a table, with keys being the same as the connected signal.
+---
+---@see SignalHandles.disconnect_all - To disconnect from these signals
 function output.connect_signal(signals)
     ---@diagnostic disable-next-line: invisible
     local handles = require("pinnacle.signal").handles.new({})

--- a/api/lua/pinnacle/output.lua
+++ b/api/lua/pinnacle/output.lua
@@ -159,11 +159,9 @@ function output.connect_for_all(callback)
         callback(handle)
     end
 
-    client.server_streaming_request(build_grpc_request_params("ConnectForAll", {}), function(response)
-        local output_name = response.output_name
-        local handle = output_handle.new(output_name)
-        callback(handle)
-    end)
+    output.connect_signal({
+        connect = callback,
+    })
 end
 
 ---@class OutputSignal

--- a/api/lua/pinnacle/output.lua
+++ b/api/lua/pinnacle/output.lua
@@ -166,6 +166,29 @@ function output.connect_for_all(callback)
     end)
 end
 
+---@class OutputSignal
+---@field connect fun(output: OutputHandle)?
+
+---@param signals OutputSignal
+---@return SignalHandles
+function output.connect_signal(signals)
+    ---@diagnostic disable-next-line: invisible
+    local handles = require("pinnacle.signal").handles.new({})
+
+    for signal, callback in pairs(signals) do
+        if signal == "connect" then
+            require("pinnacle.signal").add_callback("OutputConnect", callback)
+            ---@diagnostic disable-next-line: invisible
+            local handle = require("pinnacle.signal").handle.new("OutputConnect", callback)
+            handles[signal] = handle
+        end
+    end
+
+    return handles
+end
+
+---------------------------------------------------------------------
+
 ---Set the location of this output in the global space.
 ---
 ---On startup, Pinnacle will lay out all connected outputs starting at (0, 0)

--- a/api/lua/pinnacle/signal.lua
+++ b/api/lua/pinnacle/signal.lua
@@ -70,7 +70,7 @@ local signals = {
     WindowPointerEnter = {
         ---@type H2Stream?
         sender = nil,
-        ---@type (fun(output: OutputHandle))[]
+        ---@type (fun(window: WindowHandle))[]
         callbacks = {},
         ---@type fun(response: table)
         on_response = nil,
@@ -78,7 +78,7 @@ local signals = {
     WindowPointerLeave = {
         ---@type H2Stream?
         sender = nil,
-        ---@type (fun(output: OutputHandle))[]
+        ---@type (fun(window: WindowHandle))[]
         callbacks = {},
         ---@type fun(response: table)
         on_response = nil,
@@ -101,6 +101,24 @@ signals.Layout.on_response = function(response)
 
     for _, callback in ipairs(signals.Layout.callbacks) do
         callback(tag_handle, window_handles)
+    end
+end
+
+signals.WindowPointerEnter.on_response = function(response)
+    ---@diagnostic disable-next-line: invisible
+    local window_handle = require("pinnacle.window").handle.new(response.window_id)
+
+    for _, callback in ipairs(signals.WindowPointerEnter.callbacks) do
+        callback(window_handle)
+    end
+end
+
+signals.WindowPointerLeave.on_response = function(response)
+    ---@diagnostic disable-next-line: invisible
+    local window_handle = require("pinnacle.window").handle.new(response.window_id)
+
+    for _, callback in ipairs(signals.WindowPointerLeave.callbacks) do
+        callback(window_handle)
     end
 end
 

--- a/api/lua/pinnacle/signal.lua
+++ b/api/lua/pinnacle/signal.lua
@@ -51,6 +51,7 @@ local stream_control = {
 
 -- TODO: rewrite ldoc_gen so you don't have to stick @nodoc everywhere
 
+---@nodoc
 ---@type table<SignalServiceMethod, { sender: H2Stream?, callbacks: function[], on_response: fun(response: table) }>
 local signals = {
     OutputConnect = {
@@ -142,19 +143,20 @@ end
 ---@class SignalHandleModule
 local signal_handle = {}
 
+---@classmod
 ---A handle to a connected signal that can be used to disconnect the provided callback.
 ---
 ---@class SignalHandle
----@field signal SignalServiceMethod
----@field callback function The callback you connected
+---@field private signal SignalServiceMethod
+---@field private callback function The callback you connected
 local SignalHandle = {}
 
 ---@nodoc
 ---@class SignalHandlesModule
 local signal_handles = {}
 
----@nodoc
----@class SignalHandles
+---@classmod
+---@class SignalHandles A collection of `SignalHandle`s retreived through a `connect_signal` function.
 local SignalHandles = {}
 
 ---@nodoc
@@ -165,7 +167,7 @@ local signal = {}
 signal.handle = signal_handle
 signal.handles = signal_handles
 
----@nodoc
+---Disconnect the provided callback from this signal.
 function SignalHandle:disconnect()
     local cb_index = nil
     for i, cb in ipairs(signals[self.signal].callbacks) do

--- a/api/lua/pinnacle/signal.lua
+++ b/api/lua/pinnacle/signal.lua
@@ -49,108 +49,156 @@ local stream_control = {
     DISCONNECT = 2,
 }
 
+---@type table<SignalServiceMethod, { sender: H2Stream?, callbacks: function[], on_response: fun(response: table) }>
 local signals = {
-    output_connect = {
+    OutputConnect = {
         ---@type H2Stream?
         sender = nil,
         ---@type (fun(output: OutputHandle))[]
         callbacks = {},
+        ---@type fun(response: table)
+        on_response = nil,
     },
-    layout = {
+    Layout = {
         ---@type H2Stream?
         sender = nil,
-        ---@type (fun(windows: WindowHandle[], tag: TagHandle))[]
+        ---@type (fun(tag: TagHandle, windows: WindowHandle[]))[]
         callbacks = {},
+        ---@type fun(response: table)
+        on_response = nil,
     },
-    window_pointer_enter = {
+    WindowPointerEnter = {
         ---@type H2Stream?
         sender = nil,
         ---@type (fun(output: OutputHandle))[]
         callbacks = {},
+        ---@type fun(response: table)
+        on_response = nil,
     },
-    window_pointer_leave = {
+    WindowPointerLeave = {
         ---@type H2Stream?
         sender = nil,
         ---@type (fun(output: OutputHandle))[]
         callbacks = {},
+        ---@type fun(response: table)
+        on_response = nil,
     },
 }
 
+signals.OutputConnect.on_response = function(response)
+    ---@diagnostic disable-next-line: invisible
+    local handle = require("pinnacle.output").handle.new(response.output_name)
+    for _, callback in ipairs(signals.OutputConnect.callbacks) do
+        callback(handle)
+    end
+end
+
+signals.Layout.on_response = function(response)
+    ---@diagnostic disable-next-line: invisible
+    local window_handles = require("pinnacle.window").handle.new_from_table(response.window_ids or {})
+    ---@diagnostic disable-next-line: invisible
+    local tag_handle = require("pinnacle.tag").handle.new(response.tag_id)
+
+    for _, callback in ipairs(signals.Layout.callbacks) do
+        callback(tag_handle, window_handles)
+    end
+end
+
+-----------------------------------------------------------------------------
+
+---@class SignalHandleModule
+local signal_handle = {}
+
+---@class SignalHandle
+---@field signal SignalServiceMethod
+---@field callback function The callback you connected
+local SignalHandle = {}
+
+---@class SignalHandlesModule
+local signal_handles = {}
+
+---@class SignalHandles
+local SignalHandles = {}
+
 ---@class Signal
+---@field private handle SignalHandleModule
+---@field private handles SignalHandlesModule
 local signal = {}
+signal.handle = signal_handle
+signal.handles = signal_handles
 
----@param fn fun(windows: WindowHandle[], tag: TagHandle)
-function signal.layout_add(fn)
-    if #signals.layout.callbacks == 0 then
-        signal.layout_connect()
-    end
-
-    table.insert(signals.layout.callbacks, fn)
-end
-
-function signal.layout_dc()
-    signal.layout_disconnect()
-end
-
-function signal.output_connect_connect()
-    local stream = client.bidirectional_streaming_request(
-        build_grpc_request_params("OutputConnect", {
-            control = stream_control.READY,
-        }),
-        function(response)
-            ---@diagnostic disable-next-line: invisible
-            local handle = require("pinnacle.output").handle.new(response.output_name)
-            for _, callback in ipairs(signals.output_connect.callbacks) do
-                callback(handle)
-            end
-
-            local chunk = require("pinnacle.grpc.protobuf").encode(prefix .. "OutputConnectRequest", {
-                control = stream_control.READY,
-            })
-
-            if signals.layout.sender then
-                signals.layout.sender:write_chunk(chunk)
-            end
+function SignalHandle:disconnect()
+    local cb_index = nil
+    for i, cb in ipairs(signals[self.signal].callbacks) do
+        if cb == self.callback then
+            cb_index = i
+            break
         end
-    )
+    end
 
-    signals.output_connect.sender = stream
-end
+    if cb_index then
+        table.remove(signals[self.signal].callbacks, cb_index)
+    end
 
-function signal.output_connect_disconnect()
-    if signals.output_connect.sender then
-        local chunk = require("pinnacle.grpc.protobuf").encode(prefix .. "OutputConnectRequest", {
-            control = stream_control.DISCONNECT,
-        })
-
-        signals.output_connect.sender:write_chunk(chunk)
-        signals.output_connect.sender = nil
+    if #signals[self.signal].callbacks == 0 then
+        signal.disconnect(self.signal)
     end
 end
 
-function signal.layout_connect()
+---@return SignalHandle
+function signal_handle.new(request, callback)
+    ---@type SignalHandle
+    local self = {
+        signal = request,
+        callback = callback,
+    }
+    setmetatable(self, { __index = SignalHandle })
+    return self
+end
+
+---@param self table<string, SignalHandle>
+function SignalHandles:disconnect_all()
+    for _, sig in pairs(self) do
+        sig:disconnect()
+    end
+end
+
+---@param signal_hdls table<string, SignalHandle>
+---@return SignalHandles
+function signal_handles.new(signal_hdls)
+    ---@type SignalHandles
+    local self = signal_hdls
+    setmetatable(self, { __index = SignalHandles })
+    return self
+end
+
+---@param request SignalServiceMethod
+---@param callback function
+function signal.add_callback(request, callback)
+    if #signals[request].callbacks == 0 then
+        signal.connect(request, signals[request].on_response)
+    end
+
+    table.insert(signals[request].callbacks, callback)
+end
+
+---@param request SignalServiceMethod
+---@param callback fun(response: table)
+function signal.connect(request, callback)
     local stream = client.bidirectional_streaming_request(
         build_grpc_request_params("Layout", {
             control = stream_control.READY,
         }),
         function(response)
-            ---@diagnostic disable-next-line: invisible
-            local window_handles = require("pinnacle.window").handle.new_from_table(response.window_ids or {})
-            ---@diagnostic disable-next-line: invisible
-            local tag_handle = require("pinnacle.tag").handle.new(response.tag_id)
+            callback(response)
 
-            for _, callback in ipairs(signals.layout.callbacks) do
-                print("calling layout callback")
-                callback(window_handles, tag_handle)
-            end
+            if signals[request].sender then
+                local chunk = require("pinnacle.grpc.protobuf").encode(prefix .. request .. "Request", {
+                    control = stream_control.READY,
+                })
 
-            print("creating control request")
-            local chunk = require("pinnacle.grpc.protobuf").encode(prefix .. "LayoutRequest", {
-                control = stream_control.READY,
-            })
+                local success, err = pcall(signals[request].sender.write_chunk, signals[request].sender, chunk)
 
-            if signals.layout.sender then
-                local success, err = pcall(signals.layout.sender.write_chunk, signals.layout.sender, chunk)
                 if not success then
                     print("error sending to stream:", err)
                     os.exit(1)
@@ -159,19 +207,26 @@ function signal.layout_connect()
         end
     )
 
-    signals.layout.sender = stream
+    signals[request].sender = stream
 end
 
-function signal.layout_disconnect()
-    if signals.layout.sender then
-        local chunk = require("pinnacle.grpc.protobuf").encode(prefix .. "LayoutRequest", {
+---This should only be called when call callbacks for the signal are removed
+---@param request SignalServiceMethod
+function signal.disconnect(request)
+    if signals[request].sender then
+        local chunk = require("pinnacle.grpc.protobuf").encode(prefix .. request .. "Request", {
             control = stream_control.DISCONNECT,
         })
 
-        signals.layout.sender:write_chunk(chunk)
-        signals.layout.sender = nil
+        local success, err = pcall(signals[request].sender.write_chunk, signals[request].sender, chunk)
+        if not success then
+            print("error sending to stream:", err)
+            os.exit(1)
+        end
+
+        signals[request].sender:shutdown()
+        signals[request].sender = nil
     end
-    signals.layout.callbacks = {}
 end
 
 return signal

--- a/api/lua/pinnacle/signal.lua
+++ b/api/lua/pinnacle/signal.lua
@@ -1,0 +1,177 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+local client = require("pinnacle.grpc.client")
+
+---The protobuf absolute path prefix
+local prefix = "pinnacle.signal." .. client.version .. "."
+local service = prefix .. "SignalService"
+
+---@type table<string, { request_type: string?, response_type: string? }>
+---@enum (key) SignalServiceMethod
+local rpc_types = {
+    OutputConnect = {
+        response_type = "OutputConnectResponse",
+    },
+    Layout = {
+        response_type = "LayoutResponse",
+    },
+    WindowPointerEnter = {
+        response_type = "WindowPointerEnterResponse",
+    },
+    WindowPointerLeave = {
+        response_type = "WindowPointerLeaveResponse",
+    },
+}
+
+---Build GrpcRequestParams
+---@param method SignalServiceMethod
+---@param data table
+---@return GrpcRequestParams
+local function build_grpc_request_params(method, data)
+    local req_type = rpc_types[method].request_type
+    local resp_type = rpc_types[method].response_type
+
+    ---@type GrpcRequestParams
+    return {
+        service = service,
+        method = method,
+        request_type = req_type and prefix .. req_type or prefix .. method .. "Request",
+        response_type = resp_type and prefix .. resp_type,
+        data = data,
+    }
+end
+
+local stream_control = {
+    UNSPECIFIED = 0,
+    READY = 1,
+    DISCONNECT = 2,
+}
+
+local signals = {
+    output_connect = {
+        ---@type H2Stream?
+        sender = nil,
+        ---@type (fun(output: OutputHandle))[]
+        callbacks = {},
+    },
+    layout = {
+        ---@type H2Stream?
+        sender = nil,
+        ---@type (fun(windows: WindowHandle[], tag: TagHandle))[]
+        callbacks = {},
+    },
+    window_pointer_enter = {
+        ---@type H2Stream?
+        sender = nil,
+        ---@type (fun(output: OutputHandle))[]
+        callbacks = {},
+    },
+    window_pointer_leave = {
+        ---@type H2Stream?
+        sender = nil,
+        ---@type (fun(output: OutputHandle))[]
+        callbacks = {},
+    },
+}
+
+---@class Signal
+local signal = {}
+
+---@param fn fun(windows: WindowHandle[], tag: TagHandle)
+function signal.layout_add(fn)
+    if #signals.layout.callbacks == 0 then
+        signal.layout_connect()
+    end
+
+    table.insert(signals.layout.callbacks, fn)
+end
+
+function signal.layout_dc()
+    signal.layout_disconnect()
+end
+
+function signal.output_connect_connect()
+    local stream = client.bidirectional_streaming_request(
+        build_grpc_request_params("OutputConnect", {
+            control = stream_control.READY,
+        }),
+        function(response)
+            ---@diagnostic disable-next-line: invisible
+            local handle = require("pinnacle.output").handle.new(response.output_name)
+            for _, callback in ipairs(signals.output_connect.callbacks) do
+                callback(handle)
+            end
+
+            local chunk = require("pinnacle.grpc.protobuf").encode(prefix .. "OutputConnectRequest", {
+                control = stream_control.READY,
+            })
+
+            if signals.layout.sender then
+                signals.layout.sender:write_chunk(chunk)
+            end
+        end
+    )
+
+    signals.output_connect.sender = stream
+end
+
+function signal.output_connect_disconnect()
+    if signals.output_connect.sender then
+        local chunk = require("pinnacle.grpc.protobuf").encode(prefix .. "OutputConnectRequest", {
+            control = stream_control.DISCONNECT,
+        })
+
+        signals.output_connect.sender:write_chunk(chunk)
+        signals.output_connect.sender = nil
+    end
+end
+
+function signal.layout_connect()
+    local stream = client.bidirectional_streaming_request(
+        build_grpc_request_params("Layout", {
+            control = stream_control.READY,
+        }),
+        function(response)
+            ---@diagnostic disable-next-line: invisible
+            local window_handles = require("pinnacle.window").handle.new_from_table(response.window_ids or {})
+            ---@diagnostic disable-next-line: invisible
+            local tag_handle = require("pinnacle.tag").handle.new(response.tag_id)
+
+            for _, callback in ipairs(signals.layout.callbacks) do
+                print("calling layout callback")
+                callback(window_handles, tag_handle)
+            end
+
+            print("creating control request")
+            local chunk = require("pinnacle.grpc.protobuf").encode(prefix .. "LayoutRequest", {
+                control = stream_control.READY,
+            })
+
+            if signals.layout.sender then
+                local success, err = pcall(signals.layout.sender.write_chunk, signals.layout.sender, chunk)
+                if not success then
+                    print("error sending to stream:", err)
+                    os.exit(1)
+                end
+            end
+        end
+    )
+
+    signals.layout.sender = stream
+end
+
+function signal.layout_disconnect()
+    if signals.layout.sender then
+        local chunk = require("pinnacle.grpc.protobuf").encode(prefix .. "LayoutRequest", {
+            control = stream_control.DISCONNECT,
+        })
+
+        signals.layout.sender:write_chunk(chunk)
+        signals.layout.sender = nil
+    end
+    signals.layout.callbacks = {}
+end
+
+return signal

--- a/api/lua/pinnacle/signal.lua
+++ b/api/lua/pinnacle/signal.lua
@@ -186,7 +186,7 @@ end
 ---@param callback fun(response: table)
 function signal.connect(request, callback)
     local stream = client.bidirectional_streaming_request(
-        build_grpc_request_params("Layout", {
+        build_grpc_request_params(request, {
             control = stream_control.READY,
         }),
         function(response)

--- a/api/lua/pinnacle/signal.lua
+++ b/api/lua/pinnacle/signal.lua
@@ -155,8 +155,9 @@ local SignalHandle = {}
 ---@class SignalHandlesModule
 local signal_handles = {}
 
+---A collection of `SignalHandle`s retreived through a `connect_signal` function.
 ---@classmod
----@class SignalHandles A collection of `SignalHandle`s retreived through a `connect_signal` function.
+---@class SignalHandles
 local SignalHandles = {}
 
 ---@nodoc

--- a/api/lua/pinnacle/signal.lua
+++ b/api/lua/pinnacle/signal.lua
@@ -49,37 +49,51 @@ local stream_control = {
     DISCONNECT = 2,
 }
 
+-- TODO: rewrite ldoc_gen so you don't have to stick @nodoc everywhere
+
 ---@type table<SignalServiceMethod, { sender: H2Stream?, callbacks: function[], on_response: fun(response: table) }>
 local signals = {
     OutputConnect = {
+        ---@nodoc
         ---@type H2Stream?
         sender = nil,
+        ---@nodoc
         ---@type (fun(output: OutputHandle))[]
         callbacks = {},
+        ---@nodoc
         ---@type fun(response: table)
         on_response = nil,
     },
     Layout = {
+        ---@nodoc
         ---@type H2Stream?
         sender = nil,
+        ---@nodoc
         ---@type (fun(tag: TagHandle, windows: WindowHandle[]))[]
         callbacks = {},
+        ---@nodoc
         ---@type fun(response: table)
         on_response = nil,
     },
     WindowPointerEnter = {
+        ---@nodoc
         ---@type H2Stream?
         sender = nil,
+        ---@nodoc
         ---@type (fun(window: WindowHandle))[]
         callbacks = {},
+        ---@nodoc
         ---@type fun(response: table)
         on_response = nil,
     },
     WindowPointerLeave = {
+        ---@nodoc
         ---@type H2Stream?
         sender = nil,
+        ---@nodoc
         ---@type (fun(window: WindowHandle))[]
         callbacks = {},
+        ---@nodoc
         ---@type fun(response: table)
         on_response = nil,
     },
@@ -124,20 +138,26 @@ end
 
 -----------------------------------------------------------------------------
 
+---@nodoc
 ---@class SignalHandleModule
 local signal_handle = {}
 
+---A handle to a connected signal that can be used to disconnect the provided callback.
+---
 ---@class SignalHandle
 ---@field signal SignalServiceMethod
 ---@field callback function The callback you connected
 local SignalHandle = {}
 
+---@nodoc
 ---@class SignalHandlesModule
 local signal_handles = {}
 
+---@nodoc
 ---@class SignalHandles
 local SignalHandles = {}
 
+---@nodoc
 ---@class Signal
 ---@field private handle SignalHandleModule
 ---@field private handles SignalHandlesModule
@@ -145,6 +165,7 @@ local signal = {}
 signal.handle = signal_handle
 signal.handles = signal_handles
 
+---@nodoc
 function SignalHandle:disconnect()
     local cb_index = nil
     for i, cb in ipairs(signals[self.signal].callbacks) do
@@ -163,6 +184,7 @@ function SignalHandle:disconnect()
     end
 end
 
+---@nodoc
 ---@return SignalHandle
 function signal_handle.new(request, callback)
     ---@type SignalHandle
@@ -174,6 +196,8 @@ function signal_handle.new(request, callback)
     return self
 end
 
+---Disconnect the callbacks from all the signal connections that are stored in this handle collection.
+---
 ---@param self table<string, SignalHandle>
 function SignalHandles:disconnect_all()
     for _, sig in pairs(self) do
@@ -181,6 +205,7 @@ function SignalHandles:disconnect_all()
     end
 end
 
+---@nodoc
 ---@param signal_hdls table<string, SignalHandle>
 ---@return SignalHandles
 function signal_handles.new(signal_hdls)
@@ -190,6 +215,7 @@ function signal_handles.new(signal_hdls)
     return self
 end
 
+---@nodoc
 ---@param request SignalServiceMethod
 ---@param callback function
 function signal.add_callback(request, callback)
@@ -200,6 +226,7 @@ function signal.add_callback(request, callback)
     table.insert(signals[request].callbacks, callback)
 end
 
+---@nodoc
 ---@param request SignalServiceMethod
 ---@param callback fun(response: table)
 function signal.connect(request, callback)
@@ -228,6 +255,7 @@ function signal.connect(request, callback)
     signals[request].sender = stream
 end
 
+---@nodoc
 ---This should only be called when call callbacks for the signal are removed
 ---@param request SignalServiceMethod
 function signal.disconnect(request)

--- a/api/lua/pinnacle/tag.lua
+++ b/api/lua/pinnacle/tag.lua
@@ -319,6 +319,11 @@ function tag.new_layout_cycler(layouts)
     }
 end
 
+---@param fn fun(windows: WindowHandle[], tag: TagHandle)
+function tag.connect_layout(fn)
+    require("pinnacle.signal").layout_add(fn)
+end
+
 ---Remove this tag.
 ---
 ---### Example

--- a/api/lua/pinnacle/tag.lua
+++ b/api/lua/pinnacle/tag.lua
@@ -234,8 +234,8 @@ end
 ---layout_cycler.next() -- Layout is now "dwindle"
 ---layout_cycler.next() -- Layout is now "corner_top_left"
 ---layout_cycler.next() -- Layout is now "corner_top_right"
+---layout_cycler.next() -- Layout is now "master_stack"
 ---layout_cycler.next() -- Layout is now "dwindle"
----layout_cycler.next() -- Layout is now "corner_top_right"
 ---
 --- -- Cycling on another output
 ---layout_cycler.next(Output.get_by_name("eDP-1"))
@@ -323,11 +323,31 @@ local signal_name_to_SignalName = {
     layout = "Layout",
 }
 
----@class TagSignal
----@field layout fun(tag: TagHandle, windows: WindowHandle[])?
+---@class TagSignal Signals related to tag events.
+---@field layout fun(tag: TagHandle, windows: WindowHandle[])? The compositor requested a layout of the given tiled windows. You'll also receive the first active tag.
 
----@param signals TagSignal
----@return SignalHandles
+---Connect to a tag signal.
+---
+---The compositor sends signals about various events. Use this function to run a callback when
+---some tag signal occurs.
+---
+---This function returns a table of signal handles with each handle stored at the same key used
+---to connect to the signal. See `SignalHandles` for more information.
+---
+---# Example
+---```lua
+---Tag.connect_signal({
+---    layout = function(tag, windows)
+---        print("Compositor requested a layout")
+---    end
+---})
+---```
+---
+---@param signals TagSignal The signal you want to connect to
+---
+---@return SignalHandles signal_handles Handles to every signal you connected to wrapped in a table, with keys being the same as the connected signal.
+---
+---@see SignalHandles.disconnect_all - To disconnect from these signals
 function tag.connect_signal(signals)
     ---@diagnostic disable-next-line: invisible
     local handles = require("pinnacle.signal").handles.new({})

--- a/api/lua/pinnacle/tag.lua
+++ b/api/lua/pinnacle/tag.lua
@@ -319,9 +319,25 @@ function tag.new_layout_cycler(layouts)
     }
 end
 
----@param fn fun(windows: WindowHandle[], tag: TagHandle)
-function tag.connect_layout(fn)
-    require("pinnacle.signal").layout_add(fn)
+---@class TagSignal
+---@field layout fun(tag: TagHandle, windows: WindowHandle[])?
+
+---@param signals TagSignal
+---@return SignalHandles
+function tag.connect_signal(signals)
+    ---@diagnostic disable-next-line: invisible
+    local handles = require("pinnacle.signal").handles.new({})
+
+    for signal, callback in pairs(signals) do
+        if signal == "layout" then
+            require("pinnacle.signal").add_callback("Layout", callback)
+            ---@diagnostic disable-next-line: invisible
+            local handle = require("pinnacle.signal").handle.new("Layout", callback)
+            handles[signal] = handle
+        end
+    end
+
+    return handles
 end
 
 ---Remove this tag.

--- a/api/lua/pinnacle/tag.lua
+++ b/api/lua/pinnacle/tag.lua
@@ -319,6 +319,10 @@ function tag.new_layout_cycler(layouts)
     }
 end
 
+local signal_name_to_SignalName = {
+    layout = "Layout",
+}
+
 ---@class TagSignal
 ---@field layout fun(tag: TagHandle, windows: WindowHandle[])?
 
@@ -329,12 +333,10 @@ function tag.connect_signal(signals)
     local handles = require("pinnacle.signal").handles.new({})
 
     for signal, callback in pairs(signals) do
-        if signal == "layout" then
-            require("pinnacle.signal").add_callback("Layout", callback)
-            ---@diagnostic disable-next-line: invisible
-            local handle = require("pinnacle.signal").handle.new("Layout", callback)
-            handles[signal] = handle
-        end
+        require("pinnacle.signal").add_callback(signal_name_to_SignalName[signal], callback)
+        ---@diagnostic disable-next-line: invisible
+        local handle = require("pinnacle.signal").handle.new(signal_name_to_SignalName[signal], callback)
+        handles[signal] = handle
     end
 
     return handles

--- a/api/lua/pinnacle/tag/layout.lua
+++ b/api/lua/pinnacle/tag/layout.lua
@@ -1,0 +1,4 @@
+---@class LayoutModule
+local layout = {}
+
+return layout

--- a/api/lua/pinnacle/window.lua
+++ b/api/lua/pinnacle/window.lua
@@ -69,7 +69,9 @@ local WindowHandle = {}
 ---This module helps you deal with setting windows to fullscreen and maximized, setting their size,
 ---moving them between tags, and various other actions.
 ---@class Window
+---@field private handle WindowHandleModule
 local window = {}
+window.handle = window_handle
 
 ---Get all windows.
 ---

--- a/api/lua/pinnacle/window.lua
+++ b/api/lua/pinnacle/window.lua
@@ -311,6 +311,33 @@ function window.add_window_rule(rule)
     }))
 end
 
+local signal_name_to_SignalName = {
+    pointer_enter = "WindowPointerEnter",
+    pointer_leave = "WindowPointerLeave",
+}
+
+---@class WindowSignal
+---@field pointer_enter fun(window: WindowHandle)?
+---@field pointer_leave fun(window: WindowHandle)?
+
+---@param signals WindowSignal
+---@return SignalHandles
+function window.connect_signal(signals)
+    ---@diagnostic disable-next-line: invisible
+    local handles = require("pinnacle.signal").handles.new({})
+
+    for signal, callback in pairs(signals) do
+        require("pinnacle.signal").add_callback(signal_name_to_SignalName[signal], callback)
+        ---@diagnostic disable-next-line: invisible
+        local handle = require("pinnacle.signal").handle.new(signal_name_to_SignalName[signal], callback)
+        handles[signal] = handle
+    end
+
+    return handles
+end
+
+------------------------------------------------------------------------
+
 ---Send a close request to this window.
 ---
 ---### Example

--- a/api/lua/pinnacle/window.lua
+++ b/api/lua/pinnacle/window.lua
@@ -316,12 +316,32 @@ local signal_name_to_SignalName = {
     pointer_leave = "WindowPointerLeave",
 }
 
----@class WindowSignal
----@field pointer_enter fun(window: WindowHandle)?
----@field pointer_leave fun(window: WindowHandle)?
+---@class WindowSignal Signals related to compositor events.
+---@field pointer_enter fun(window: WindowHandle)? The pointer entered a window.
+---@field pointer_leave fun(window: WindowHandle)? The pointer left a window.
 
----@param signals WindowSignal
----@return SignalHandles
+---Connect to a window signal.
+---
+---The compositor sends signals about various events. Use this function to run a callback when
+---some window signal occurs.
+---
+---This function returns a table of signal handles with each handle stored at the same key used
+---to connect to the signal. See `SignalHandles` for more information.
+---
+---# Example
+---```lua
+---Window.connect_signal({
+---    pointer_enter = function(window)
+---        print("Pointer entered", window:class())
+---    end
+---})
+---```
+---
+---@param signals WindowSignal The signal you want to connect to
+---
+---@return SignalHandles signal_handles Handles to every signal you connected to wrapped in a table, with keys being the same as the connected signal.
+---
+---@see SignalHandles.disconnect_all - To disconnect from these signals
 function window.connect_signal(signals)
     ---@diagnostic disable-next-line: invisible
     local handles = require("pinnacle.signal").handles.new({})

--- a/api/protocol/pinnacle/output/v0alpha1/output.proto
+++ b/api/protocol/pinnacle/output/v0alpha1/output.proto
@@ -10,11 +10,6 @@ message SetLocationRequest {
   optional int32 y = 3;
 }
 
-message ConnectForAllRequest {}
-message ConnectForAllResponse {
-  optional string output_name = 1;
-}
-
 message GetRequest {}
 message GetResponse {
   repeated string output_names = 1;
@@ -41,7 +36,6 @@ message GetPropertiesResponse {
 
 service OutputService {
   rpc SetLocation(SetLocationRequest) returns (google.protobuf.Empty);
-  rpc ConnectForAll(ConnectForAllRequest) returns (stream ConnectForAllResponse);
   rpc Get(GetRequest) returns (GetResponse);
   rpc GetProperties(GetPropertiesRequest) returns (GetPropertiesResponse);
 }

--- a/api/protocol/pinnacle/signal/v0alpha1/signal.proto
+++ b/api/protocol/pinnacle/signal/v0alpha1/signal.proto
@@ -1,0 +1,53 @@
+syntax = "proto2";
+
+package pinnacle.signal.v0alpha1;
+
+import "google/protobuf/empty.proto";
+
+enum StreamControl {
+  STREAM_CONTROL_UNSPECIFIED = 0;
+  // The client is ready to receive the next signal.
+  STREAM_CONTROL_READY = 1;
+  // The client wishes to disconnect a signal connection.
+  STREAM_CONTROL_DISCONNECT = 2;
+}
+
+message OutputConnectRequest {
+  optional StreamControl control = 1;
+}
+message OutputConnectResponse {
+  optional string output_name = 1;
+}
+
+message LayoutRequest {
+  optional StreamControl control = 1;
+}
+message LayoutResponse {
+  // The windows that need to be laid out.
+  repeated uint32 window_ids = 1;
+  // The tag that is being laid out.
+  optional uint32 tag_id = 2;
+}
+
+message WindowPointerEnterRequest {
+  optional StreamControl control = 1;
+}
+message WindowPointerEnterResponse {
+  // The window that the pointer entered.
+  optional uint32 window_id = 1;
+}
+
+message WindowPointerLeaveRequest {
+  optional StreamControl control = 1;
+}
+message WindowPointerLeaveResponse {
+  // The window that the pointer left.
+  optional uint32 window_id = 1;
+}
+
+service SignalService {
+  rpc OutputConnect(stream OutputConnectRequest) returns (stream OutputConnectResponse);
+  rpc Layout(stream LayoutRequest) returns (stream LayoutResponse);
+  rpc WindowPointerEnter(stream WindowPointerEnterRequest) returns (stream WindowPointerEnterResponse);
+  rpc WindowPointerLeave(stream WindowPointerLeaveRequest) returns (stream WindowPointerLeaveResponse);
+}

--- a/api/protocol/pinnacle/signal/v0alpha1/signal.proto
+++ b/api/protocol/pinnacle/signal/v0alpha1/signal.proto
@@ -2,8 +2,6 @@ syntax = "proto2";
 
 package pinnacle.signal.v0alpha1;
 
-import "google/protobuf/empty.proto";
-
 enum StreamControl {
   STREAM_CONTROL_UNSPECIFIED = 0;
   // The client is ready to receive the next signal.

--- a/api/rust/Cargo.toml
+++ b/api/rust/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["api-bindings", "config"]
 pinnacle-api-defs = { workspace = true }
 pinnacle-api-macros = { path = "./pinnacle-api-macros" }
 tokio = { workspace = true, features = ["net"] }
+tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tower = { version = "0.4.13", features = ["util"] }
 futures = "0.3.30"

--- a/api/rust/examples/default_config/main.rs
+++ b/api/rust/examples/default_config/main.rs
@@ -83,10 +83,10 @@ async fn main() {
 
     // Setup all monitors with tags "1" through "5"
     output.connect_for_all(move |op| {
-        let mut tags = tag.add(&op, tag_names);
+        let tags = tag.add(op, tag_names);
 
         // Be sure to set a tag to active or windows won't display
-        tags.next().unwrap().set_active(true);
+        tags.first().unwrap().set_active(true);
     });
 
     process.spawn_once([terminal]);

--- a/api/rust/src/input.rs
+++ b/api/rust/src/input.rs
@@ -8,7 +8,7 @@
 //! methods for setting key- and mousebinds, changing xkeyboard settings, and more.
 //! View the struct's documentation for more information.
 
-use futures::{channel::mpsc::UnboundedSender, future::BoxFuture, FutureExt, StreamExt};
+use futures::{future::BoxFuture, FutureExt, StreamExt};
 use num_enum::TryFromPrimitive;
 use pinnacle_api_defs::pinnacle::input::{
     self,
@@ -19,6 +19,7 @@ use pinnacle_api_defs::pinnacle::input::{
         SetXkbConfigRequest,
     },
 };
+use tokio::sync::mpsc::UnboundedSender;
 use tonic::transport::Channel;
 use xkbcommon::xkb::Keysym;
 
@@ -162,7 +163,7 @@ impl Input {
         let modifiers = mods.into_iter().map(|modif| modif as i32).collect();
 
         self.fut_sender
-            .unbounded_send(
+            .send(
                 async move {
                     let mut stream = client
                         .set_keybind(SetKeybindRequest {
@@ -218,7 +219,7 @@ impl Input {
         let modifiers = mods.into_iter().map(|modif| modif as i32).collect();
 
         self.fut_sender
-            .unbounded_send(
+            .send(
                 async move {
                     let mut stream = client
                         .set_mousebind(SetMousebindRequest {

--- a/api/rust/src/lib.rs
+++ b/api/rust/src/lib.rs
@@ -81,15 +81,18 @@
 
 use std::sync::OnceLock;
 
-use futures::{
-    channel::mpsc::UnboundedReceiver, future::BoxFuture, stream::FuturesUnordered, Future,
-    StreamExt,
-};
+use futures::{future::BoxFuture, stream::FuturesUnordered, Future, StreamExt};
 use input::Input;
 use output::Output;
 use pinnacle::Pinnacle;
 use process::Process;
+use signal::SignalState;
 use tag::Tag;
+use tokio::sync::{
+    mpsc::{unbounded_channel, UnboundedReceiver},
+    RwLock,
+};
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
 use window::Window;
@@ -98,6 +101,7 @@ pub mod input;
 pub mod output;
 pub mod pinnacle;
 pub mod process;
+pub mod signal;
 pub mod tag;
 pub mod util;
 pub mod window;
@@ -112,6 +116,7 @@ static WINDOW: OnceLock<Window> = OnceLock::new();
 static INPUT: OnceLock<Input> = OnceLock::new();
 static OUTPUT: OnceLock<Output> = OnceLock::new();
 static TAG: OnceLock<Tag> = OnceLock::new();
+static SIGNAL: OnceLock<RwLock<SignalState>> = OnceLock::new();
 
 /// A struct containing static references to all of the configuration structs.
 #[derive(Debug, Clone, Copy)]
@@ -145,16 +150,21 @@ pub async fn connect(
         }))
         .await?;
 
-    let (fut_sender, fut_recv) = futures::channel::mpsc::unbounded::<BoxFuture<()>>();
-
-    let output = Output::new(channel.clone(), fut_sender.clone());
+    let (fut_sender, fut_recv) = unbounded_channel::<BoxFuture<()>>();
 
     let pinnacle = PINNACLE.get_or_init(|| Pinnacle::new(channel.clone()));
     let process = PROCESS.get_or_init(|| Process::new(channel.clone(), fut_sender.clone()));
     let window = WINDOW.get_or_init(|| Window::new(channel.clone()));
     let input = INPUT.get_or_init(|| Input::new(channel.clone(), fut_sender.clone()));
-    let tag = TAG.get_or_init(|| Tag::new(channel.clone(), fut_sender.clone()));
-    let output = OUTPUT.get_or_init(|| output);
+    let tag = TAG.get_or_init(|| Tag::new(channel.clone()));
+    let output = OUTPUT.get_or_init(|| Output::new(channel.clone()));
+
+    SIGNAL
+        .set(RwLock::new(SignalState::new(
+            channel.clone(),
+            fut_sender.clone(),
+        )))
+        .map_err(|_| "failed to create SIGNAL")?;
 
     let modules = ApiModules {
         pinnacle,
@@ -176,10 +186,12 @@ pub async fn connect(
 /// This function is inserted at the end of your config through the [`config`] macro.
 /// You should use the macro instead of this function directly.
 pub async fn listen(fut_recv: UnboundedReceiver<BoxFuture<'static, ()>>) {
+    let fut_recv = UnboundedReceiverStream::new(fut_recv);
+
     let mut future_set = FuturesUnordered::<
         BoxFuture<(
             Option<BoxFuture<()>>,
-            Option<UnboundedReceiver<BoxFuture<()>>>,
+            Option<UnboundedReceiverStream<BoxFuture<()>>>,
         )>,
     >::new();
 

--- a/api/rust/src/process.rs
+++ b/api/rust/src/process.rs
@@ -7,10 +7,11 @@
 //! This module provides [`Process`], which allows you to spawn processes and set environment
 //! variables.
 
-use futures::{channel::mpsc::UnboundedSender, future::BoxFuture, FutureExt, StreamExt};
+use futures::{future::BoxFuture, FutureExt, StreamExt};
 use pinnacle_api_defs::pinnacle::process::v0alpha1::{
     process_service_client::ProcessServiceClient, SetEnvRequest, SpawnRequest,
 };
+use tokio::sync::mpsc::UnboundedSender;
 use tonic::transport::Channel;
 
 use crate::block_on_tokio;
@@ -133,7 +134,7 @@ impl Process {
         };
 
         self.fut_sender
-            .unbounded_send(
+            .send(
                 async move {
                     let mut stream = client.spawn(request).await.unwrap().into_inner();
                     let Some(mut callbacks) = callbacks else { return };

--- a/api/rust/src/signal.rs
+++ b/api/rust/src/signal.rs
@@ -1,0 +1,372 @@
+//! Signals TODO:
+
+use std::{
+    collections::{btree_map, BTreeMap},
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
+};
+
+use futures::{future::BoxFuture, pin_mut, FutureExt};
+use pinnacle_api_defs::pinnacle::signal::v0alpha1::{
+    signal_service_client::SignalServiceClient, SignalRequest, StreamControl,
+};
+use tokio::sync::{
+    mpsc::{unbounded_channel, UnboundedSender},
+    oneshot,
+};
+use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
+use tonic::{transport::Channel, Streaming};
+
+use crate::{
+    block_on_tokio, output::OutputHandle, tag::TagHandle, window::WindowHandle, OUTPUT, TAG, WINDOW,
+};
+
+pub(crate) trait Signal {
+    type Callback;
+}
+
+macro_rules! signals {
+    ( $(
+        $( #[$cfg_enum:meta] )* $enum:ident => {
+            $(
+                $( #[$cfg:meta] )* $name:ident = {
+                    enum_name = $renamed:ident,
+                    callback_type = $cb:ty,
+                    client_request = $req:ident,
+                    on_response = $on_resp:expr,
+                }
+            )*
+        }
+    )* ) => {$(
+        $(
+            $( #[$cfg] )*
+            pub(crate) struct $name;
+
+            impl $crate::signal::Signal for $name {
+                type Callback = $cb;
+            }
+
+            impl SignalData<$name> {
+                pub(crate) fn add_callback(&mut self, callback: <$name as Signal>::Callback) -> SignalHandle {
+                    if self.callback_count.load(::std::sync::atomic::Ordering::SeqCst) == 0 {
+                        self.connect()
+                    }
+
+                    let Some(callback_sender) = self.callback_sender.as_ref() else {
+                        unreachable!("signal should already be connected here");
+                    };
+
+                    let Some(remove_callback_sender) = self.remove_callback_sender.clone() else {
+                        unreachable!("signal should already be connected here");
+                    };
+
+                    callback_sender
+                        .send((self.current_id, callback))
+                        .expect("failed to send callback");
+
+                    let handle = SignalHandle::new(self.current_id, remove_callback_sender);
+
+                    self.current_id.0 += 1;
+
+                    handle
+                }
+
+                fn reset(&mut self) {
+                    self.callback_sender.take();
+                    self.dc_pinger.take();
+                    self.remove_callback_sender.take();
+                    self.callback_count.store(0, Ordering::SeqCst);
+                    self.current_id = SignalConnId::default();
+                }
+
+                fn connect(&mut self) {
+                    self.reset();
+
+                    let channels = connect_signal::<_, _, <$name as Signal>::Callback, _, _>(
+                        &self.fut_sender,
+                        self.callback_count.clone(),
+                        |out| {
+                            block_on_tokio(self.client.$req(out))
+                                .expect("TODO")
+                                .into_inner()
+                        },
+                        $on_resp,
+                    );
+
+                    self.callback_sender.replace(channels.callback_sender);
+                    self.dc_pinger.replace(channels.dc_pinger);
+                    self.remove_callback_sender
+                        .replace(channels.remove_callback_sender);
+                }
+            }
+        )*
+
+        $( #[$cfg_enum] )*
+        pub enum $enum {
+            $( $( #[$cfg] )* $renamed($cb),)*
+        }
+    )*};
+}
+
+signals! {
+    /// Signals relating to tag events.
+    TagSignal => {
+        /// The compositor requested that the given windows be laid out.
+        Layout = {
+            enum_name = Layout,
+            callback_type = LayoutFn,
+            client_request = layout,
+            on_response = |response, callbacks| {
+                if let Some(tag_id) = response.tag_id {
+                    let tag = TAG.get().expect("TAG doesn't exist");
+                    let window = WINDOW.get().expect("WINDOW doesn't exist");
+                    let tag = tag.new_handle(tag_id);
+
+                    let windows = response
+                        .window_ids
+                        .into_iter()
+                        .map(|id| window.new_handle(id))
+                        .collect::<Vec<_>>();
+
+                    for callback in callbacks {
+                        callback(&tag, windows.as_slice());
+                    }
+                }
+            },
+        }
+    }
+    /// Signals relating to output events.
+    OutputSignal => {
+        /// An output was connected.
+        OutputConnect = {
+            enum_name = Connect,
+            callback_type = SingleOutputFn,
+            client_request = output_connect,
+            on_response = |response, callbacks| {
+                if let Some(output_name) = response.output_name {
+                    let output = OUTPUT.get().expect("OUTPUT doesn't exist");
+                    let handle = output.new_handle(output_name);
+
+                    for callback in callbacks {
+                        callback(&handle);
+                    }
+                }
+            },
+        }
+    }
+    /// Signals relating to window events.
+    WindowSignal => {
+        /// The pointer entered a window.
+        WindowPointerEnter = {
+            enum_name = PointerEnter,
+            callback_type = SingleWindowFn,
+            client_request = window_pointer_enter,
+            on_response = |response, callbacks| {
+                if let Some(window_id) = response.window_id {
+                    let window = WINDOW.get().expect("WINDOW doesn't exist");
+                    let handle = window.new_handle(window_id);
+
+                    for callback in callbacks {
+                        callback(&handle);
+                    }
+                }
+            },
+        }
+        /// The pointer left a window.
+        WindowPointerLeave = {
+            enum_name = PointerLeave,
+            callback_type = SingleWindowFn,
+            client_request = window_pointer_leave,
+            on_response = |response, callbacks| {
+                if let Some(window_id) = response.window_id {
+                    let window = WINDOW.get().expect("WINDOW doesn't exist");
+                    let handle = window.new_handle(window_id);
+
+                    for callback in callbacks {
+                        callback(&handle);
+                    }
+                }
+            },
+        }
+    }
+}
+
+pub(crate) type LayoutFn = Box<dyn FnMut(&TagHandle, &[WindowHandle]) + Send + 'static>;
+pub(crate) type SingleOutputFn = Box<dyn FnMut(&OutputHandle) + Send + 'static>;
+pub(crate) type SingleWindowFn = Box<dyn FnMut(&WindowHandle) + Send + 'static>;
+
+pub(crate) struct SignalState {
+    pub(crate) layout: SignalData<Layout>,
+    pub(crate) output_connect: SignalData<OutputConnect>,
+    pub(crate) window_pointer_enter: SignalData<WindowPointerEnter>,
+    pub(crate) window_pointer_leave: SignalData<WindowPointerLeave>,
+}
+
+impl SignalState {
+    pub(crate) fn new(
+        channel: Channel,
+        fut_sender: UnboundedSender<BoxFuture<'static, ()>>,
+    ) -> Self {
+        let client = SignalServiceClient::new(channel);
+        Self {
+            layout: SignalData::new(client.clone(), fut_sender.clone()),
+            output_connect: SignalData::new(client.clone(), fut_sender.clone()),
+            window_pointer_enter: SignalData::new(client.clone(), fut_sender.clone()),
+            window_pointer_leave: SignalData::new(client.clone(), fut_sender.clone()),
+        }
+    }
+}
+
+#[derive(Default, Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct SignalConnId(pub(crate) u32);
+
+pub(crate) struct SignalData<S: Signal> {
+    client: SignalServiceClient<Channel>,
+    fut_sender: UnboundedSender<BoxFuture<'static, ()>>,
+    callback_sender: Option<UnboundedSender<(SignalConnId, S::Callback)>>,
+    remove_callback_sender: Option<UnboundedSender<SignalConnId>>,
+    dc_pinger: Option<oneshot::Sender<()>>,
+    current_id: SignalConnId,
+    callback_count: Arc<AtomicU32>,
+}
+
+impl<S: Signal> SignalData<S> {
+    fn new(
+        client: SignalServiceClient<Channel>,
+        fut_sender: UnboundedSender<BoxFuture<'static, ()>>,
+    ) -> Self {
+        Self {
+            client,
+            fut_sender,
+            callback_sender: Default::default(),
+            remove_callback_sender: Default::default(),
+            dc_pinger: Default::default(),
+            current_id: Default::default(),
+            callback_count: Default::default(),
+        }
+    }
+}
+
+struct ConnectSignalChannels<F> {
+    callback_sender: UnboundedSender<(SignalConnId, F)>,
+    dc_pinger: oneshot::Sender<()>,
+    remove_callback_sender: UnboundedSender<SignalConnId>,
+}
+
+fn connect_signal<Req, Resp, F, T, O>(
+    fut_sender: &UnboundedSender<BoxFuture<'static, ()>>,
+    callback_count: Arc<AtomicU32>,
+    to_in_stream: T,
+    mut on_response: O,
+) -> ConnectSignalChannels<F>
+where
+    Req: SignalRequest + Send + 'static,
+    Resp: 'static,
+    F: Send + 'static,
+    T: FnOnce(UnboundedReceiverStream<Req>) -> Streaming<Resp>,
+    O: FnMut(Resp, btree_map::ValuesMut<'_, SignalConnId, F>) + Send + 'static,
+{
+    let (control_sender, recv) = unbounded_channel::<Req>();
+    let out_stream = UnboundedReceiverStream::new(recv);
+
+    let mut in_stream = to_in_stream(out_stream);
+
+    let (callback_sender, mut callback_recv) = unbounded_channel::<(SignalConnId, F)>();
+    let (remove_callback_sender, mut remove_callback_recv) = unbounded_channel::<SignalConnId>();
+    let (dc_pinger, mut dc_ping_recv) = oneshot::channel::<()>();
+
+    let signal_future = async move {
+        let mut callbacks = BTreeMap::<SignalConnId, F>::new();
+
+        control_sender
+            .send(Req::from_control(StreamControl::Ready))
+            .expect("send failed");
+
+        loop {
+            let in_stream_next = in_stream.next().fuse();
+            pin_mut!(in_stream_next);
+            let callback_recv_recv = callback_recv.recv().fuse();
+            pin_mut!(callback_recv_recv);
+            let remove_callback_recv_recv = remove_callback_recv.recv().fuse();
+            pin_mut!(remove_callback_recv_recv);
+            let mut dc_ping_recv_fuse = (&mut dc_ping_recv).fuse();
+
+            futures::select! {
+                response = in_stream_next => {
+                    let Some(response) = response else { continue };
+
+                    match response {
+                        Ok(response) => {
+                            on_response(response, callbacks.values_mut());
+
+                            control_sender
+                                .send(Req::from_control(StreamControl::Ready))
+                                .expect("send failed");
+                        }
+                        Err(status) => eprintln!("Error in recv: {status}"),
+                    }
+                }
+                callback = callback_recv_recv => {
+                    if let Some((id, callback)) = callback {
+                        callbacks.insert(id, callback);
+                        callback_count.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+                remove = remove_callback_recv_recv => {
+                    if let Some(id) = remove {
+                        if callbacks.remove(&id).is_some() {
+                            assert!(callback_count.fetch_sub(1, Ordering::SeqCst) > 0);
+                        }
+                        if callbacks.is_empty() {
+                            assert!(callback_count.load(Ordering::SeqCst) == 0);
+                            control_sender.send(Req::from_control(StreamControl::Disconnect)).expect("send failed");
+                            break;
+                        }
+                    }
+                }
+                _dc = dc_ping_recv_fuse => {
+                    println!("dc");
+                    control_sender.send(Req::from_control(StreamControl::Disconnect)).expect("send failed");
+                    break;
+                }
+            }
+        }
+    };
+
+    fut_sender.send(signal_future.boxed()).expect("send failed");
+
+    ConnectSignalChannels {
+        callback_sender,
+        dc_pinger,
+        remove_callback_sender,
+    }
+}
+
+/// A handle that can be used to disconnect from a signal connection.
+///
+/// This will remove the connected callback.
+pub struct SignalHandle {
+    id: SignalConnId,
+    remove_callback_sender: UnboundedSender<SignalConnId>,
+}
+
+impl SignalHandle {
+    pub(crate) fn new(
+        id: SignalConnId,
+        remove_callback_sender: UnboundedSender<SignalConnId>,
+    ) -> Self {
+        Self {
+            id,
+            remove_callback_sender,
+        }
+    }
+
+    /// Disconnect this signal connection.
+    pub fn disconnect(self) {
+        self.remove_callback_sender
+            .send(self.id)
+            .expect("failed to disconnect signal");
+    }
+}

--- a/api/rust/src/signal.rs
+++ b/api/rust/src/signal.rs
@@ -263,7 +263,7 @@ fn connect_signal<Req, Resp, F, T, O>(
 ) -> ConnectSignalChannels<F>
 where
     Req: SignalRequest + Send + 'static,
-    Resp: 'static,
+    Resp: Send + 'static,
     F: Send + 'static,
     T: FnOnce(UnboundedReceiverStream<Req>) -> Streaming<Resp>,
     O: FnMut(Resp, btree_map::ValuesMut<'_, SignalConnId, F>) + Send + 'static,
@@ -300,6 +300,7 @@ where
                     match response {
                         Ok(response) => {
                             on_response(response, callbacks.values_mut());
+                            tokio::task::yield_now().await;
 
                             control_sender
                                 .send(Req::from_control(StreamControl::Ready))

--- a/api/rust/src/window.rs
+++ b/api/rust/src/window.rs
@@ -122,12 +122,12 @@ impl Window {
     /// ```
     /// let windows = window.get_all();
     /// ```
-    pub fn get_all(&self) -> impl Iterator<Item = WindowHandle> {
+    pub fn get_all(&self) -> Vec<WindowHandle> {
         block_on_tokio(self.get_all_async())
     }
 
     /// The async version of [`Window::get_all`].
-    pub async fn get_all_async(&self) -> impl Iterator<Item = WindowHandle> {
+    pub async fn get_all_async(&self) -> Vec<WindowHandle> {
         let mut client = self.window_client.clone();
         client
             .get(GetRequest {})
@@ -138,8 +138,6 @@ impl Window {
             .into_iter()
             .map(move |id| self.new_handle(id))
             .collect::<Vec<_>>()
-            // TODO: consider changing return type to Vec to avoid this into_iter
-            .into_iter()
     }
 
     /// Get the currently focused window.
@@ -166,7 +164,7 @@ impl Window {
     /// A window rule is a set of criteria that a window must open with.
     /// For it to apply, a [`WindowRuleCondition`] must evaluate to true for the window in question.
     ///
-    /// TODO:
+    /// See the [`rules`] module for more information.
     pub fn add_window_rule(&self, cond: WindowRuleCondition, rule: WindowRule) {
         let mut client = self.window_client.clone();
 

--- a/pinnacle-api-defs/build.rs
+++ b/pinnacle-api-defs/build.rs
@@ -13,6 +13,7 @@ fn main() {
         formatcp!("../api/protocol/pinnacle/process/{VERSION}/process.proto"),
         formatcp!("../api/protocol/pinnacle/tag/{VERSION}/tag.proto"),
         formatcp!("../api/protocol/pinnacle/window/{VERSION}/window.proto"),
+        formatcp!("../api/protocol/pinnacle/signal/{VERSION}/signal.proto"),
     ];
 
     let descriptor_path = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("pinnacle.bin");

--- a/pinnacle-api-defs/src/lib.rs
+++ b/pinnacle-api-defs/src/lib.rs
@@ -33,6 +33,12 @@ pub mod pinnacle {
             tonic::include_proto!("pinnacle.process.v0alpha1");
         }
     }
+
+    pub mod signal {
+        pub mod v0alpha1 {
+            tonic::include_proto!("pinnacle.signal.v0alpha1");
+        }
+    }
 }
 
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("pinnacle");

--- a/pinnacle-api-defs/src/lib.rs
+++ b/pinnacle-api-defs/src/lib.rs
@@ -37,6 +37,36 @@ pub mod pinnacle {
     pub mod signal {
         pub mod v0alpha1 {
             tonic::include_proto!("pinnacle.signal.v0alpha1");
+
+            pub trait SignalRequest {
+                fn from_control(control: StreamControl) -> Self;
+                fn control(&self) -> StreamControl;
+            }
+
+            macro_rules! impl_signal_request {
+                ( $( $request:ident ),* ) => {
+                    $(
+                        impl SignalRequest for $request {
+                            fn from_control(control: StreamControl) -> Self {
+                                $request {
+                                    control: Some(control as i32),
+                                }
+                            }
+
+                            fn control(&self) -> StreamControl {
+                                self.control()
+                            }
+                        }
+                    )*
+                };
+            }
+
+            impl_signal_request!(
+                OutputConnectRequest,
+                LayoutRequest,
+                WindowPointerEnterRequest,
+                WindowPointerLeaveRequest
+            );
         }
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -12,9 +12,7 @@ use pinnacle_api_defs::pinnacle::{
     },
     output::{
         self,
-        v0alpha1::{
-            output_service_server, ConnectForAllRequest, ConnectForAllResponse, SetLocationRequest,
-        },
+        v0alpha1::{output_service_server, SetLocationRequest},
     },
     process::v0alpha1::{process_service_server, SetEnvRequest, SpawnRequest, SpawnResponse},
     tag::{
@@ -944,8 +942,6 @@ impl OutputService {
 
 #[tonic::async_trait]
 impl output_service_server::OutputService for OutputService {
-    type ConnectForAllStream = ResponseStream<ConnectForAllResponse>;
-
     async fn set_location(
         &self,
         request: Request<SetLocationRequest>,
@@ -995,18 +991,6 @@ impl output_service_server::OutputService for OutputService {
             state.update_windows(&output);
         })
         .await
-    }
-
-    // TODO: remove this and integrate it into a signal/event system
-    async fn connect_for_all(
-        &self,
-        _request: Request<ConnectForAllRequest>,
-    ) -> Result<Response<Self::ConnectForAllStream>, Status> {
-        tracing::trace!("OutputService.connect_for_all");
-
-        run_server_streaming(&self.sender, move |state, sender| {
-            state.config.output_callback_senders.push(sender);
-        })
     }
 
     async fn get(

--- a/src/api/signal.rs
+++ b/src/api/signal.rs
@@ -2,8 +2,8 @@ use std::collections::VecDeque;
 
 use pinnacle_api_defs::pinnacle::signal::v0alpha1::{
     signal_service_server, LayoutRequest, LayoutResponse, OutputConnectRequest,
-    OutputConnectResponse, StreamControl, WindowPointerEnterRequest, WindowPointerEnterResponse,
-    WindowPointerLeaveRequest, WindowPointerLeaveResponse,
+    OutputConnectResponse, SignalRequest, StreamControl, WindowPointerEnterRequest,
+    WindowPointerEnterResponse, WindowPointerLeaveRequest, WindowPointerLeaveResponse,
 };
 use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
 use tonic::{Request, Response, Status, Streaming};
@@ -117,29 +117,6 @@ impl<T, B: SignalBuffer<T>> SignalData<T, B> {
         }
     }
 }
-
-trait SignalRequest {
-    fn control(&self) -> StreamControl;
-}
-
-macro_rules! impl_signal_request {
-    ( $( $request:ident ),* ) => {
-        $(
-            impl SignalRequest for $request {
-                fn control(&self) -> StreamControl {
-                    self.control()
-                }
-            }
-        )*
-    };
-}
-
-impl_signal_request!(
-    OutputConnectRequest,
-    LayoutRequest,
-    WindowPointerEnterRequest,
-    WindowPointerLeaveRequest
-);
 
 fn start_signal_stream<I, O, B, F>(
     sender: StateFnSender,

--- a/src/api/signal.rs
+++ b/src/api/signal.rs
@@ -1,0 +1,188 @@
+use pinnacle_api_defs::pinnacle::signal::v0alpha1::{
+    signal_service_server, LayoutRequest, LayoutResponse, OutputConnectRequest,
+    OutputConnectResponse, StreamControl, WindowPointerEnterRequest, WindowPointerEnterResponse,
+    WindowPointerLeaveRequest, WindowPointerLeaveResponse,
+};
+use tokio::sync::mpsc::UnboundedSender;
+use tonic::{Request, Response, Status, Streaming};
+
+use crate::state::State;
+
+use super::{run_bidirectional_streaming, ResponseStream, StateFnSender};
+
+#[derive(Debug, Default)]
+pub struct SignalState {
+    pub output_connect: SignalData<OutputConnectResponse>,
+    pub layout: SignalData<LayoutResponse>,
+    pub window_pointer_enter: SignalData<WindowPointerEnterResponse>,
+    pub window_pointer_leave: SignalData<WindowPointerLeaveResponse>,
+}
+
+#[derive(Debug, Default)]
+pub struct SignalData<T> {
+    sender: Option<UnboundedSender<Result<T, Status>>>,
+    ready: bool,
+    value: Option<T>,
+}
+
+impl<T> SignalData<T> {
+    pub fn signal(&mut self, with_data: impl FnOnce(Option<T>) -> T) {
+        let Some(sender) = self.sender.as_ref() else {
+            return;
+        };
+
+        if self.ready {
+            sender
+                .send(Ok(with_data(self.value.take())))
+                .expect("failed to send signal");
+            self.ready = false;
+        } else {
+            self.value = Some(with_data(self.value.take()));
+        }
+    }
+
+    pub fn connect(&mut self, sender: UnboundedSender<Result<T, Status>>) {
+        self.sender.replace(sender);
+    }
+
+    fn disconnect(&mut self) {
+        self.sender.take();
+        self.ready = false;
+        self.value.take();
+    }
+
+    fn ready(&mut self) {
+        let Some(sender) = self.sender.as_ref() else {
+            return;
+        };
+
+        if let Some(value) = self.value.take() {
+            sender.send(Ok(value)).expect("failed to send signal");
+            self.ready = false;
+        } else {
+            self.ready = true;
+        }
+    }
+}
+
+trait SignalRequest {
+    fn control(&self) -> StreamControl;
+}
+
+macro_rules! impl_signal_request {
+    ( $( $request:ident ),* ) => {
+        $(
+            impl SignalRequest for $request {
+                fn control(&self) -> StreamControl {
+                    self.control()
+                }
+            }
+        )*
+    };
+}
+
+impl_signal_request!(
+    OutputConnectRequest,
+    LayoutRequest,
+    WindowPointerEnterRequest,
+    WindowPointerLeaveRequest
+);
+
+fn start_signal_stream<I: SignalRequest, O>(
+    sender: StateFnSender,
+    in_stream: Streaming<I>,
+    signal: impl Fn(&mut State) -> &mut SignalData<O> + Clone + Send + 'static,
+) -> Result<Response<ResponseStream<O>>, Status>
+where
+    I: Send + 'static,
+    O: Send + 'static,
+{
+    let signal_clone = signal.clone();
+
+    run_bidirectional_streaming(
+        sender,
+        in_stream,
+        move |state, request| {
+            let request = match request {
+                Ok(request) => request,
+                Err(status) => {
+                    tracing::error!("Error in output_connect signal in stream: {status}");
+                    return;
+                }
+            };
+
+            let signal = signal(state);
+            match request.control() {
+                StreamControl::Ready => signal.ready(),
+                StreamControl::Disconnect => signal.disconnect(),
+                StreamControl::Unspecified => tracing::warn!("Received unspecified stream control"),
+            }
+        },
+        move |state, sender| {
+            let signal = signal_clone(state);
+            signal.connect(sender);
+        },
+    )
+}
+
+pub struct SignalService {
+    sender: StateFnSender,
+}
+
+impl SignalService {
+    pub fn new(sender: StateFnSender) -> Self {
+        Self { sender }
+    }
+}
+
+#[tonic::async_trait]
+impl signal_service_server::SignalService for SignalService {
+    type OutputConnectStream = ResponseStream<OutputConnectResponse>;
+    type LayoutStream = ResponseStream<LayoutResponse>;
+    type WindowPointerEnterStream = ResponseStream<WindowPointerEnterResponse>;
+    type WindowPointerLeaveStream = ResponseStream<WindowPointerLeaveResponse>;
+
+    async fn output_connect(
+        &self,
+        request: Request<Streaming<OutputConnectRequest>>,
+    ) -> Result<Response<Self::OutputConnectStream>, Status> {
+        let in_stream = request.into_inner();
+
+        start_signal_stream(self.sender.clone(), in_stream, |state| {
+            &mut state.signal_state.output_connect
+        })
+    }
+
+    async fn layout(
+        &self,
+        request: Request<Streaming<LayoutRequest>>,
+    ) -> Result<Response<Self::LayoutStream>, Status> {
+        let in_stream = request.into_inner();
+
+        start_signal_stream(self.sender.clone(), in_stream, |state| {
+            &mut state.signal_state.layout
+        })
+    }
+
+    async fn window_pointer_enter(
+        &self,
+        request: Request<Streaming<WindowPointerEnterRequest>>,
+    ) -> Result<Response<Self::WindowPointerEnterStream>, Status> {
+        let in_stream = request.into_inner();
+
+        start_signal_stream(self.sender.clone(), in_stream, |state| {
+            &mut state.signal_state.window_pointer_enter
+        })
+    }
+
+    async fn window_pointer_leave(
+        &self,
+        request: Request<Streaming<WindowPointerLeaveRequest>>,
+    ) -> Result<Response<Self::WindowPointerLeaveStream>, Status> {
+        let in_stream = request.into_inner();
+
+        start_signal_stream(self.sender.clone(), in_stream, |state| {
+            &mut state.signal_state.window_pointer_leave
+        })
+    }
+}

--- a/src/api/signal.rs
+++ b/src/api/signal.rs
@@ -22,6 +22,15 @@ pub struct SignalState {
         SignalData<WindowPointerLeaveResponse, VecDeque<WindowPointerLeaveResponse>>,
 }
 
+impl SignalState {
+    pub fn clear(&mut self) {
+        self.output_connect.disconnect();
+        self.layout.disconnect();
+        self.window_pointer_enter.disconnect();
+        self.window_pointer_leave.disconnect();
+    }
+}
+
 #[derive(Debug, Default)]
 #[allow(private_bounds)]
 pub struct SignalData<T, B: SignalBuffer<T>> {

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -8,7 +8,9 @@ use std::{
 };
 
 use anyhow::Context;
-use pinnacle_api_defs::pinnacle::output::v0alpha1::ConnectForAllResponse;
+use pinnacle_api_defs::pinnacle::{
+    output::v0alpha1::ConnectForAllResponse, signal::v0alpha1::OutputConnectResponse,
+};
 use smithay::{
     backend::{
         allocator::{
@@ -989,6 +991,12 @@ impl State {
                     output_name: Some(output.name()),
                 }));
             }
+
+            self.signal_state.output_connect.signal(|buffer| {
+                buffer.push_back(OutputConnectResponse {
+                    output_name: Some(output.name()),
+                })
+            });
         }
     }
 

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -8,9 +8,7 @@ use std::{
 };
 
 use anyhow::Context;
-use pinnacle_api_defs::pinnacle::{
-    output::v0alpha1::ConnectForAllResponse, signal::v0alpha1::OutputConnectResponse,
-};
+use pinnacle_api_defs::pinnacle::signal::v0alpha1::OutputConnectResponse;
 use smithay::{
     backend::{
         allocator::{
@@ -985,13 +983,6 @@ impl State {
 
             output.with_state(|state| state.tags = tags.clone());
         } else {
-            // Run any output callbacks
-            for sender in self.config.output_callback_senders.iter() {
-                let _ = sender.send(Ok(ConnectForAllResponse {
-                    output_name: Some(output.name()),
-                }));
-            }
-
             self.signal_state.output_connect.signal(|buffer| {
                 buffer.push_back(OutputConnectResponse {
                     output_name: Some(output.name()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::{
-        InputService, OutputService, PinnacleService, ProcessService, TagService, WindowService,
+        signal::SignalService, InputService, OutputService, PinnacleService, ProcessService,
+        TagService, WindowService,
     },
     input::ModifierMask,
     output::OutputName,
@@ -18,6 +19,7 @@ use pinnacle_api_defs::pinnacle::{
     input::v0alpha1::input_service_server::InputServiceServer,
     output::v0alpha1::{output_service_server::OutputServiceServer, ConnectForAllResponse},
     process::v0alpha1::process_service_server::ProcessServiceServer,
+    signal::v0alpha1::signal_service_server::SignalServiceServer,
     tag::v0alpha1::tag_service_server::TagServiceServer,
     v0alpha1::pinnacle_service_server::PinnacleServiceServer,
     window::v0alpha1::window_service_server::WindowServiceServer,
@@ -447,6 +449,7 @@ impl State {
         let tag_service = TagService::new(grpc_sender.clone());
         let output_service = OutputService::new(grpc_sender.clone());
         let window_service = WindowService::new(grpc_sender.clone());
+        let signal_service = SignalService::new(grpc_sender.clone());
 
         let refl_service = tonic_reflection::server::Builder::configure()
             .register_encoded_file_descriptor_set(pinnacle_api_defs::FILE_DESCRIPTOR_SET)
@@ -464,7 +467,8 @@ impl State {
             .add_service(ProcessServiceServer::new(process_service))
             .add_service(TagServiceServer::new(tag_service))
             .add_service(OutputServiceServer::new(output_service))
-            .add_service(WindowServiceServer::new(window_service));
+            .add_service(WindowServiceServer::new(window_service))
+            .add_service(SignalServiceServer::new(signal_service));
 
         match self.xdisplay.as_ref() {
             Some(_) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ use std::{
 use anyhow::Context;
 use pinnacle_api_defs::pinnacle::{
     input::v0alpha1::input_service_server::InputServiceServer,
-    output::v0alpha1::{output_service_server::OutputServiceServer, ConnectForAllResponse},
+    output::v0alpha1::output_service_server::OutputServiceServer,
     process::v0alpha1::process_service_server::ProcessServiceServer,
     signal::v0alpha1::signal_service_server::SignalServiceServer,
     tag::v0alpha1::tag_service_server::TagServiceServer,
@@ -30,7 +30,7 @@ use smithay::{
     utils::{Logical, Point},
 };
 use sysinfo::ProcessRefreshKind;
-use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
+use tokio::task::JoinHandle;
 use toml::Table;
 
 use xdg::BaseDirectories;
@@ -166,7 +166,6 @@ pub enum Key {
 pub struct Config {
     /// Window rules and conditions on when those rules should apply
     pub window_rules: Vec<(WindowRuleCondition, WindowRule)>,
-    pub output_callback_senders: Vec<UnboundedSender<Result<ConnectForAllResponse, tonic::Status>>>,
     /// Saved states when outputs are disconnected
     pub connector_saved_states: HashMap<OutputName, ConnectorSavedState>,
 
@@ -177,7 +176,6 @@ pub struct Config {
 impl Config {
     pub fn clear(&mut self, loop_handle: &LoopHandle<State>) {
         self.window_rules.clear();
-        self.output_callback_senders.clear();
         self.connector_saved_states.clear();
         if let Some(join_handle) = self.config_join_handle.take() {
             join_handle.abort();

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,6 +265,8 @@ impl State {
 
         self.config.clear(&self.loop_handle);
 
+        self.signal_state.clear();
+
         // Because the grpc server is implemented to only start once,
         // any updates to `socket_dir` won't be applied until restart.
         if self.grpc_server_join_handle.is_none() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use crate::{
-    backend::Backend, config::Config, cursor::Cursor, focus::FocusState,
+    api::signal::SignalState, backend::Backend, config::Config, cursor::Cursor, focus::FocusState,
     grab::resize_grab::ResizeSurfaceState, window::WindowElement,
 };
 use anyhow::Context;
@@ -93,6 +93,8 @@ pub struct State {
     pub grpc_server_join_handle: Option<tokio::task::JoinHandle<()>>,
 
     pub xdg_base_dirs: BaseDirectories,
+
+    pub signal_state: SignalState,
 }
 
 impl State {
@@ -269,6 +271,8 @@ impl State {
 
             xdg_base_dirs: BaseDirectories::with_prefix("pinnacle")
                 .context("couldn't create xdg BaseDirectories")?,
+
+            signal_state: SignalState::default(),
         };
 
         Ok(state)

--- a/src/window/window_state.rs
+++ b/src/window/window_state.rs
@@ -17,20 +17,14 @@ use super::WindowElement;
 
 /// A unique identifier for each window.
 #[derive(Debug, Hash, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum WindowId {
-    /// A config API returned an invalid window. It should be using this variant.
-    None,
-    /// A valid window id.
-    #[serde(untagged)]
-    Some(u32),
-}
+pub struct WindowId(pub u32);
 
 static WINDOW_ID_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 impl WindowId {
     /// Get the next available window id. This always starts at 0.
     pub fn next() -> Self {
-        Self::Some(WINDOW_ID_COUNTER.fetch_add(1, Ordering::Relaxed))
+        Self(WINDOW_ID_COUNTER.fetch_add(1, Ordering::Relaxed))
     }
 
     /// Get the window that has this WindowId.


### PR DESCRIPTION
This is a successor to #158, which is way too large in scope; I definitely bit off more than I could chew.

Compared to that PR, this one only adds 4 signals:
- Output connect
- Layout
- Window pointer enter
- Window pointer leave

These signals won't have much use until I add stuff to make them useful.

Additionally, this PR implements application-level flow control for signals. In #158, I ran into problems where the compositor sent signals too fast and the client couldn't keep up. This PR should fix that by having the APIs signal readiness to receive more signals.