### PR TITLE
Rework focus and add `Window.set_focused`

### DIFF
--- a/api/lua/examples/default/default_config.lua
+++ b/api/lua/examples/default/default_config.lua
@@ -142,4 +142,11 @@ require("pinnacle").setup(function(Pinnacle)
             end
         end)
     end
+
+    -- Enable sloppy focus
+    Window.connect_signal({
+        pointer_enter = function(window)
+            window:set_focused(true)
+        end,
+    })
 end)

--- a/api/lua/pinnacle/grpc/protobuf.lua
+++ b/api/lua/pinnacle/grpc/protobuf.lua
@@ -18,6 +18,7 @@ function protobuf.build_protos()
         PINNACLE_PROTO_DIR .. "/pinnacle/process/" .. version .. "/process.proto",
         PINNACLE_PROTO_DIR .. "/pinnacle/window/" .. version .. "/window.proto",
         PINNACLE_PROTO_DIR .. "/pinnacle/signal/" .. version .. "/signal.proto",
+        PINNACLE_PROTO_DIR .. "/google/protobuf/empty.proto",
     }
 
     local cmd = "protoc --descriptor_set_out=/tmp/pinnacle.pb --proto_path=" .. PINNACLE_PROTO_DIR .. " "

--- a/api/lua/pinnacle/tag.lua
+++ b/api/lua/pinnacle/tag.lua
@@ -44,6 +44,14 @@ local function build_grpc_request_params(method, data)
     }
 end
 
+local set_or_toggle = {
+    SET = 1,
+    [true] = 1,
+    UNSET = 2,
+    [false] = 2,
+    TOGGLE = 3,
+}
+
 ---@nodoc
 ---@class TagHandleModule
 local tag_handle = {}
@@ -445,7 +453,9 @@ end
 ---
 ---@param active boolean
 function TagHandle:set_active(active)
-    client.unary_request(build_grpc_request_params("SetActive", { tag_id = self.id, set = active }))
+    client.unary_request(
+        build_grpc_request_params("SetActive", { tag_id = self.id, set_or_toggle = set_or_toggle[active] })
+    )
 end
 
 ---Toggle this tag's active state.
@@ -460,7 +470,9 @@ end
 ---Tag.get("2"):toggle_active() -- Displays nothing
 ---```
 function TagHandle:toggle_active()
-    client.unary_request(build_grpc_request_params("SetActive", { tag_id = self.id, toggle = {} }))
+    client.unary_request(
+        build_grpc_request_params("SetActive", { tag_id = self.id, set_or_toggle = set_or_toggle.TOGGLE })
+    )
 end
 
 ---@class TagProperties

--- a/api/lua/pinnacle/util.lua
+++ b/api/lua/pinnacle/util.lua
@@ -58,6 +58,10 @@ local util = {}
 ---
 ---@return T[] responses The results of each request in the same order that they were in `requests`.
 function util.batch(requests)
+    if #requests == 0 then
+        return {}
+    end
+
     local loop = require("cqueues").new()
 
     local responses = {}

--- a/api/lua/pinnacle/window.lua
+++ b/api/lua/pinnacle/window.lua
@@ -16,6 +16,7 @@ local rpc_types = {
     SetFullscreen = {},
     SetMaximized = {},
     SetFloating = {},
+    SetFocused = {},
     MoveToTag = {},
     SetTag = {},
     MoveGrab = {},
@@ -46,6 +47,14 @@ local function build_grpc_request_params(method, data)
         data = data,
     }
 end
+
+local set_or_toggle = {
+    SET = 1,
+    [true] = 1,
+    UNSET = 2,
+    [false] = 2,
+    TOGGLE = 3,
+}
 
 ---@nodoc
 ---@class WindowHandleModule
@@ -412,7 +421,9 @@ end
 ---
 ---@param fullscreen boolean
 function WindowHandle:set_fullscreen(fullscreen)
-    client.unary_request(build_grpc_request_params("SetFullscreen", { window_id = self.id, set = fullscreen }))
+    client.unary_request(
+        build_grpc_request_params("SetFullscreen", { window_id = self.id, set_or_toggle = set_or_toggle[fullscreen] })
+    )
 end
 
 ---Toggle this window to and from fullscreen.
@@ -425,7 +436,9 @@ end
 ---end
 ---```
 function WindowHandle:toggle_fullscreen()
-    client.unary_request(build_grpc_request_params("SetFullscreen", { window_id = self.id, toggle = {} }))
+    client.unary_request(
+        build_grpc_request_params("SetFullscreen", { window_id = self.id, set_or_toggle = set_or_toggle.TOGGLE })
+    )
 end
 
 ---Set this window to maximized or not.
@@ -441,7 +454,9 @@ end
 ---
 ---@param maximized boolean
 function WindowHandle:set_maximized(maximized)
-    client.unary_request(build_grpc_request_params("SetMaximized", { window_id = self.id, set = maximized }))
+    client.unary_request(
+        build_grpc_request_params("SetMaximized", { window_id = self.id, set_or_toggle = set_or_toggle[maximized] })
+    )
 end
 
 ---Toggle this window to and from maximized.
@@ -454,7 +469,9 @@ end
 ---end
 ---```
 function WindowHandle:toggle_maximized()
-    client.unary_request(build_grpc_request_params("SetMaximized", { window_id = self.id, toggle = {} }))
+    client.unary_request(
+        build_grpc_request_params("SetMaximized", { window_id = self.id, set_or_toggle = set_or_toggle.TOGGLE })
+    )
 end
 
 ---Set this window to floating or not.
@@ -470,7 +487,9 @@ end
 ---
 ---@param floating boolean
 function WindowHandle:set_floating(floating)
-    client.unary_request(build_grpc_request_params("SetFloating", { window_id = self.id, set = floating }))
+    client.unary_request(
+        build_grpc_request_params("SetFloating", { window_id = self.id, set_or_toggle = set_or_toggle[floating] })
+    )
 end
 
 ---Toggle this window to and from floating.
@@ -483,7 +502,41 @@ end
 ---end
 ---```
 function WindowHandle:toggle_floating()
-    client.unary_request(build_grpc_request_params("SetFloating", { window_id = self.id, toggle = {} }))
+    client.unary_request(
+        build_grpc_request_params("SetFloating", { window_id = self.id, set_or_toggle = set_or_toggle.TOGGLE })
+    )
+end
+
+---Focus or unfocus this window.
+---
+---### Example
+---```lua
+---local focused = Window.get_focused()
+---if focused then
+---    focused:set_focused(false)
+---end
+---```
+---
+---@param focused boolean
+function WindowHandle:set_focused(focused)
+    client.unary_request(
+        build_grpc_request_params("SetFocused", { window_id = self.id, set_or_toggle = set_or_toggle[focused] })
+    )
+end
+
+---Toggle this window to and from focused.
+---
+---### Example
+---```lua
+---local focused = Window.get_focused()
+---if focused then
+---    focused:toggle_focused()
+---end
+---```
+function WindowHandle:toggle_focused()
+    client.unary_request(
+        build_grpc_request_params("SetFocused", { window_id = self.id, set_or_toggle = set_or_toggle.TOGGLE })
+    )
 end
 
 ---Move this window to the specified tag.
@@ -523,7 +576,12 @@ end
 ---@param tag TagHandle The tag to set or unset
 ---@param set boolean
 function WindowHandle:set_tag(tag, set)
-    client.unary_request(build_grpc_request_params("SetTag", { window_id = self.id, tag_id = tag.id, set = set }))
+    client.unary_request(
+        build_grpc_request_params(
+            "SetTag",
+            { window_id = self.id, tag_id = tag.id, set_or_toggle = set_or_toggle[set] }
+        )
+    )
 end
 
 ---Toggle the given tag on this window.
@@ -545,7 +603,12 @@ end
 ---
 ---@param tag TagHandle The tag to toggle
 function WindowHandle:toggle_tag(tag)
-    client.unary_request(build_grpc_request_params("SetTag", { window_id = self.id, tag_id = tag.id, toggle = {} }))
+    client.unary_request(
+        build_grpc_request_params(
+            "SetTag",
+            { window_id = self.id, tag_id = tag.id, set_or_toggle = set_or_toggle.TOGGLE }
+        )
+    )
 end
 
 ---@class WindowProperties

--- a/api/protocol/pinnacle/tag/v0alpha1/tag.proto
+++ b/api/protocol/pinnacle/tag/v0alpha1/tag.proto
@@ -3,13 +3,11 @@ syntax = "proto2";
 package pinnacle.tag.v0alpha1;
 
 import "google/protobuf/empty.proto";
+import "pinnacle/v0alpha1/pinnacle.proto";
 
 message SetActiveRequest {
   optional uint32 tag_id = 1;
-  oneof set_or_toggle {
-    bool set = 2;
-    google.protobuf.Empty toggle = 3;
-  }
+  optional .pinnacle.v0alpha1.SetOrToggle set_or_toggle = 2;
 }
 
 message SwitchToRequest {

--- a/api/protocol/pinnacle/v0alpha1/pinnacle.proto
+++ b/api/protocol/pinnacle/v0alpha1/pinnacle.proto
@@ -11,6 +11,14 @@ message Geometry {
   optional int32 height = 4;
 }
 
+// NOTE TO SELF: If you change this you MUST change the mappings in the Lua API
+enum SetOrToggle {
+  SET_OR_TOGGLE_UNSPECIFIED = 0;
+  SET_OR_TOGGLE_SET = 1;
+  SET_OR_TOGGLE_UNSET = 2;
+  SET_OR_TOGGLE_TOGGLE = 3;
+}
+
 message QuitRequest {}
 
 service PinnacleService {

--- a/api/protocol/pinnacle/window/v0alpha1/window.proto
+++ b/api/protocol/pinnacle/window/v0alpha1/window.proto
@@ -17,26 +17,22 @@ message SetGeometryRequest {
 
 message SetFullscreenRequest {
   optional uint32 window_id = 1;
-  oneof set_or_toggle {
-    bool set = 2;
-    google.protobuf.Empty toggle = 3;
-  }
+  optional .pinnacle.v0alpha1.SetOrToggle set_or_toggle = 2;
 }
 
 message SetMaximizedRequest {
   optional uint32 window_id = 1;
-  oneof set_or_toggle {
-    bool set = 2;
-    google.protobuf.Empty toggle = 3;
-  }
+  optional .pinnacle.v0alpha1.SetOrToggle set_or_toggle = 2;
 }
 
 message SetFloatingRequest {
   optional uint32 window_id = 1;
-  oneof set_or_toggle {
-    bool set = 2;
-    google.protobuf.Empty toggle = 3;
-  }
+  optional .pinnacle.v0alpha1.SetOrToggle set_or_toggle = 2;
+}
+
+message SetFocusedRequest {
+  optional uint32 window_id = 1;
+  optional .pinnacle.v0alpha1.SetOrToggle set_or_toggle = 2;
 }
 
 message MoveToTagRequest {
@@ -47,10 +43,7 @@ message MoveToTagRequest {
 message SetTagRequest {
   optional uint32 window_id = 1;
   optional uint32 tag_id = 2;
-  oneof set_or_toggle {
-    bool set = 3;
-    google.protobuf.Empty toggle = 4;
-  }
+  optional .pinnacle.v0alpha1.SetOrToggle set_or_toggle = 3;
 }
 
 message MoveGrabRequest {
@@ -119,6 +112,7 @@ service WindowService {
   rpc SetFullscreen(SetFullscreenRequest) returns (google.protobuf.Empty);
   rpc SetMaximized(SetMaximizedRequest) returns (google.protobuf.Empty);
   rpc SetFloating(SetFloatingRequest) returns (google.protobuf.Empty);
+  rpc SetFocused(SetFocusedRequest) returns (google.protobuf.Empty);
   rpc MoveToTag(MoveToTagRequest) returns (google.protobuf.Empty);
   rpc SetTag(SetTagRequest) returns (google.protobuf.Empty);
   rpc MoveGrab(MoveGrabRequest) returns (google.protobuf.Empty);

--- a/api/rust/examples/default_config/main.rs
+++ b/api/rust/examples/default_config/main.rs
@@ -1,3 +1,4 @@
+use pinnacle_api::signal::WindowSignal;
 use pinnacle_api::xkbcommon::xkb::Keysym;
 use pinnacle_api::{
     input::{Mod, MouseButton, MouseEdge},
@@ -148,4 +149,9 @@ async fn main() {
             }
         });
     }
+
+    // Enable sloppy focus
+    window.connect_signal(WindowSignal::PointerEnter(Box::new(|win| {
+        win.set_focused(true);
+    })));
 }

--- a/api/rust/src/tag.rs
+++ b/api/rust/src/tag.rs
@@ -36,12 +36,15 @@ use std::{
 
 use futures::FutureExt;
 use num_enum::TryFromPrimitive;
-use pinnacle_api_defs::pinnacle::tag::{
-    self,
-    v0alpha1::{
-        tag_service_client::TagServiceClient, AddRequest, RemoveRequest, SetActiveRequest,
-        SetLayoutRequest, SwitchToRequest,
+use pinnacle_api_defs::pinnacle::{
+    tag::{
+        self,
+        v0alpha1::{
+            tag_service_client::TagServiceClient, AddRequest, RemoveRequest, SetActiveRequest,
+            SetLayoutRequest, SwitchToRequest,
+        },
     },
+    v0alpha1::SetOrToggle,
 };
 use tonic::transport::Channel;
 
@@ -451,7 +454,10 @@ impl TagHandle {
         let mut client = self.tag_client.clone();
         block_on_tokio(client.set_active(SetActiveRequest {
             tag_id: Some(self.id),
-            set_or_toggle: Some(tag::v0alpha1::set_active_request::SetOrToggle::Set(set)),
+            set_or_toggle: Some(match set {
+                true => SetOrToggle::Set,
+                false => SetOrToggle::Unset,
+            } as i32),
         }))
         .unwrap();
     }
@@ -479,7 +485,7 @@ impl TagHandle {
         let mut client = self.tag_client.clone();
         block_on_tokio(client.set_active(SetActiveRequest {
             tag_id: Some(self.id),
-            set_or_toggle: Some(tag::v0alpha1::set_active_request::SetOrToggle::Toggle(())),
+            set_or_toggle: Some(SetOrToggle::Toggle as i32),
         }))
         .unwrap();
     }

--- a/api/rust/src/window.rs
+++ b/api/rust/src/window.rs
@@ -15,15 +15,13 @@
 use futures::FutureExt;
 use num_enum::TryFromPrimitive;
 use pinnacle_api_defs::pinnacle::{
-    window::v0alpha1::{
-        window_service_client::WindowServiceClient, AddWindowRuleRequest, CloseRequest,
-        MoveToTagRequest, SetTagRequest,
-    },
+    v0alpha1::SetOrToggle,
     window::{
         self,
         v0alpha1::{
-            GetRequest, MoveGrabRequest, ResizeGrabRequest, SetFloatingRequest,
-            SetFullscreenRequest, SetMaximizedRequest,
+            window_service_client::WindowServiceClient, AddWindowRuleRequest, CloseRequest,
+            GetRequest, MoveGrabRequest, MoveToTagRequest, ResizeGrabRequest, SetFloatingRequest,
+            SetFocusedRequest, SetFullscreenRequest, SetMaximizedRequest, SetTagRequest,
         },
     },
 };
@@ -280,9 +278,10 @@ impl WindowHandle {
         let mut client = self.window_client.clone();
         block_on_tokio(client.set_fullscreen(SetFullscreenRequest {
             window_id: Some(self.id),
-            set_or_toggle: Some(window::v0alpha1::set_fullscreen_request::SetOrToggle::Set(
-                set,
-            )),
+            set_or_toggle: Some(match set {
+                true => SetOrToggle::Set,
+                false => SetOrToggle::Unset,
+            } as i32),
         }))
         .unwrap();
     }
@@ -301,7 +300,7 @@ impl WindowHandle {
         let mut client = self.window_client.clone();
         block_on_tokio(client.set_fullscreen(SetFullscreenRequest {
             window_id: Some(self.id),
-            set_or_toggle: Some(window::v0alpha1::set_fullscreen_request::SetOrToggle::Toggle(())),
+            set_or_toggle: Some(SetOrToggle::Toggle as i32),
         }))
         .unwrap();
     }
@@ -320,9 +319,10 @@ impl WindowHandle {
         let mut client = self.window_client.clone();
         block_on_tokio(client.set_maximized(SetMaximizedRequest {
             window_id: Some(self.id),
-            set_or_toggle: Some(window::v0alpha1::set_maximized_request::SetOrToggle::Set(
-                set,
-            )),
+            set_or_toggle: Some(match set {
+                true => SetOrToggle::Set,
+                false => SetOrToggle::Unset,
+            } as i32),
         }))
         .unwrap();
     }
@@ -341,7 +341,7 @@ impl WindowHandle {
         let mut client = self.window_client.clone();
         block_on_tokio(client.set_maximized(SetMaximizedRequest {
             window_id: Some(self.id),
-            set_or_toggle: Some(window::v0alpha1::set_maximized_request::SetOrToggle::Toggle(())),
+            set_or_toggle: Some(SetOrToggle::Toggle as i32),
         }))
         .unwrap();
     }
@@ -363,9 +363,10 @@ impl WindowHandle {
         let mut client = self.window_client.clone();
         block_on_tokio(client.set_floating(SetFloatingRequest {
             window_id: Some(self.id),
-            set_or_toggle: Some(window::v0alpha1::set_floating_request::SetOrToggle::Set(
-                set,
-            )),
+            set_or_toggle: Some(match set {
+                true => SetOrToggle::Set,
+                false => SetOrToggle::Unset,
+            } as i32),
         }))
         .unwrap();
     }
@@ -387,9 +388,46 @@ impl WindowHandle {
         let mut client = self.window_client.clone();
         block_on_tokio(client.set_floating(SetFloatingRequest {
             window_id: Some(self.id),
-            set_or_toggle: Some(window::v0alpha1::set_floating_request::SetOrToggle::Toggle(
-                (),
-            )),
+            set_or_toggle: Some(SetOrToggle::Toggle as i32),
+        }))
+        .unwrap();
+    }
+
+    /// Focus or unfocus this window.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // Unfocus the focused window
+    /// window.get_focused()?.set_focused(false);
+    /// ```
+    pub fn set_focused(&self, set: bool) {
+        let mut client = self.window_client.clone();
+        block_on_tokio(client.set_focused(SetFocusedRequest {
+            window_id: Some(self.id),
+            set_or_toggle: Some(match set {
+                true => SetOrToggle::Set,
+                false => SetOrToggle::Unset,
+            } as i32),
+        }))
+        .unwrap();
+    }
+
+    /// Toggle this window to and from focused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // Toggle the focused window to and from floating.
+    /// // Calling this a second time will do nothing because there won't
+    /// // be a focused window.
+    /// window.get_focused()?.toggle_focused();
+    /// ```
+    pub fn toggle_focused(&self) {
+        let mut client = self.window_client.clone();
+        block_on_tokio(client.set_focused(SetFocusedRequest {
+            window_id: Some(self.id),
+            set_or_toggle: Some(SetOrToggle::Toggle as i32),
         }))
         .unwrap();
     }
@@ -432,7 +470,10 @@ impl WindowHandle {
         block_on_tokio(client.set_tag(SetTagRequest {
             window_id: Some(self.id),
             tag_id: Some(tag.id),
-            set_or_toggle: Some(window::v0alpha1::set_tag_request::SetOrToggle::Set(set)),
+            set_or_toggle: Some(match set {
+                true => SetOrToggle::Set,
+                false => SetOrToggle::Unset,
+            } as i32),
         }))
         .unwrap();
     }
@@ -456,7 +497,7 @@ impl WindowHandle {
         block_on_tokio(client.set_tag(SetTagRequest {
             window_id: Some(self.id),
             tag_id: Some(tag.id),
-            set_or_toggle: Some(window::v0alpha1::set_tag_request::SetOrToggle::Toggle(())),
+            set_or_toggle: Some(SetOrToggle::Toggle as i32),
         }))
         .unwrap();
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1698,8 +1698,11 @@ impl window_service_server::WindowService for WindowService {
             });
 
             let focused = window.as_ref().and_then(|win| {
-                let output = win.output(state)?;
-                state.focused_window(&output).map(|foc_win| win == &foc_win)
+                state
+                    .output_focus_stack
+                    .current_focus()
+                    .and_then(|output| state.focused_window(output))
+                    .map(|foc_win| win == &foc_win)
             });
 
             let floating = window

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -516,6 +516,7 @@ pub fn run_udev() -> anyhow::Result<()> {
         Some(Duration::from_micros(((1.0 / 144.0) * 1000000.0) as u64)),
         &mut state,
         |state| {
+            state.fixup_focus();
             state.space.refresh();
             state.popup_manager.cleanup();
             state
@@ -1251,13 +1252,6 @@ impl State {
                 pointer_images.push((frame, texture.clone()));
                 texture
             });
-
-        // let windows = self
-        //     .output_focus_stack
-        //     .stack
-        //     .iter()
-        //     .flat_map(|op| op.with_state(|state| state.focus_stack.stack.clone()))
-        //     .collect::<Vec<_>>();
 
         let windows = self.space.elements().cloned().collect::<Vec<_>>();
 

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -30,7 +30,7 @@ use smithay::{
 
 use crate::{
     render::{pointer::PointerElement, take_presentation_feedback},
-    state::{State, WithState},
+    state::State,
 };
 
 use super::{Backend, BackendData};

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -30,7 +30,7 @@ use smithay::{
 
 use crate::{
     render::{pointer::PointerElement, take_presentation_feedback},
-    state::State,
+    state::{State, WithState},
 };
 
 use super::{Backend, BackendData};
@@ -165,7 +165,7 @@ pub fn run_winit() -> anyhow::Result<()> {
         evt_loop_handle,
     )?;
 
-    state.focus_state.focused_output = Some(output.clone());
+    state.output_focus_stack.set_focus(output.clone());
 
     let winit = state.backend.winit_mut();
 
@@ -237,6 +237,7 @@ pub fn run_winit() -> anyhow::Result<()> {
         Some(Duration::from_micros(((1.0 / 144.0) * 1000000.0) as u64)),
         &mut state,
         |state| {
+            state.fixup_focus();
             state.space.refresh();
             state.popup_manager.cleanup();
             state
@@ -256,8 +257,6 @@ impl State {
         let full_redraw = &mut winit.full_redraw;
         *full_redraw = full_redraw.saturating_sub(1);
 
-        self.focus_state.fix_up_focus(&mut self.space);
-
         if let CursorImageStatus::Surface(surface) = &self.cursor_status {
             if !surface.alive() {
                 self.cursor_status = CursorImageStatus::default_named();
@@ -269,11 +268,15 @@ impl State {
         let mut pointer_element = PointerElement::<GlesTexture>::new();
         pointer_element.set_status(self.cursor_status.clone());
 
+        // The z-index of these is determined by `state.fixup_focus()`, which is called at the end
+        // of every event loop cycle
+        let windows = self.space.elements().cloned().collect::<Vec<_>>();
+
         let output_render_elements = crate::render::generate_render_elements(
             output,
             winit.backend.renderer(),
             &self.space,
-            &self.focus_state.focus_stack,
+            &windows,
             self.pointer_location,
             &mut self.cursor_status,
             self.dnd_icon.as_ref(),
@@ -316,7 +319,7 @@ impl State {
 
                 // Send frames to the cursor surface so it updates correctly
                 if let CursorImageStatus::Surface(surf) = &self.cursor_status {
-                    if let Some(op) = self.focus_state.focused_output.as_ref() {
+                    if let Some(op) = self.output_focus_stack.current_focus() {
                         send_frames_surface_tree(surf, op, time, Some(Duration::ZERO), |_, _| None);
                     }
                 }

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -21,8 +21,9 @@ use crate::{
 impl State {
     /// Get the currently focused window on `output`
     /// that isn't an override redirect window, if any.
-    pub fn focused_window(&mut self, output: &Output) -> Option<WindowElement> {
-        output.with_state(|state| state.focus_stack.stack.retain(|win| win.alive()));
+    pub fn focused_window(&self, output: &Output) -> Option<WindowElement> {
+        // TODO: see if the below is necessary
+        // output.with_state(|state| state.focus_stack.stack.retain(|win| win.alive()));
 
         let windows = output.with_state(|state| {
             state

--- a/src/output.rs
+++ b/src/output.rs
@@ -5,8 +5,10 @@ use std::cell::RefCell;
 use smithay::output::Output;
 
 use crate::{
+    focus::FocusStack,
     state::{State, WithState},
     tag::Tag,
+    window::WindowElement,
 };
 
 /// A unique identifier for an output.
@@ -31,6 +33,7 @@ impl OutputName {
 #[derive(Default, Debug)]
 pub struct OutputState {
     pub tags: Vec<Tag>,
+    pub focus_stack: FocusStack<WindowElement>,
 }
 
 impl WithState for Output {


### PR DESCRIPTION
This PR reworks focus to be per output and not global. It also decouples windows' z-index from the keyboard focus stack.

Additionally, `Window.set_focused` has been added, meaning this PR also enables sloppy focus.