### PR TITLE
Embed default rust config in binary

### DIFF
--- a/.github/workflows/ci.pinnacle.yml
+++ b/.github/workflows/ci.pinnacle.yml
@@ -51,10 +51,12 @@ jobs:
           luaVersion: "5.4"
       - name: Setup LuaRocks
         uses: leafo/gh-actions-luarocks@v4
-      - name: Build
+      - name: Install Lua library
+        run: cd ./api/lua && luarocks make --local
+      - name: Test
         if: ${{ runner.debug != '1' }}
         run: cargo test -- --test-threads=1
-      - name: Build (debug)
+      - name: Test (debug)
         if: ${{ runner.debug == '1' }}
         run: RUST_LOG=debug cargo test -- --nocapture --test-threads=1
   check-format:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,11 +70,12 @@ x11rb = { version = "0.13.0", default-features = false, features = ["composite"]
 xkbcommon = { workspace = true }
 xdg = { workspace = true }
 sysinfo = "0.30.10"
-nix = { version = "0.28.0", features = ["user", "resource"] }
+nix = { version = "0.28.0", features = ["user", "resource", "process", "signal"] }
 pinnacle-api-defs = { workspace = true }
 dircpy = { workspace = true }
 chrono = "0.4.37"
 bytemuck = "1.15.0"
+pinnacle-api = { path = "./api/rust" }
 
 [dependencies.smithay]
 git = "https://github.com/Smithay/smithay"

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ at `$XDG_DATA_HOME/pinnacle/default_config/lua` (typically `~/.local/share/pinna
 Additionally, if your config crashes, Pinnacle will also start the default Lua config.
 
 > [!NOTE]
-> If you have not run `eval $(luarocks path --lua-version 5.4)`, Pinnacle will go into an endless loop of
-> starting the default Lua config only for it to crash because it can't find the Lua library.
+> If you have not run `eval $(luarocks path --lua-version 5.4)`, Pinnacle will fallback to the
+> embedded Rust config.
 
 ### The `metaconfig.toml` file
 A `metaconfig.toml` file must contain the following entries:

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ for Wayland.
 # Dependencies
 You will need:
 
-- [Rust](https://www.rust-lang.org/) 1.74 or newer
-    - If you want to use the Rust API, you will need Rust 1.75 or newer
-- [Lua](https://www.lua.org/) 5.4 or newer, to use the Lua API
+- [Rust](https://www.rust-lang.org/) 1.75 or newer
 - Packages for [Smithay](https://github.com/Smithay/smithay):
   `libwayland libxkbcommon libudev libinput libgdm libseat`, as well as `xwayland`
     - Arch:
@@ -66,8 +64,6 @@ You will need:
     - NixOS: There is flake [`flake.nix`](flake.nix) with a devShell. It also
       includes the other tools needed for the build and sets up the
       `LD_LIBRARY_PATH` so the dynamically loaded libraries are found.
-
-      > [!NOTE]
       > Luarocks currently doesn't install the Lua library and its dependencies due to openssh directory
       > shenanigans. Fix soon, hopefully. In the meantime you can use the Rust API.
 - [protoc](https://grpc.io/docs/protoc-installation/), the Protocol Buffer Compiler, for configuration
@@ -79,7 +75,11 @@ You will need:
         ```sh
         sudo apt install protobuf-compiler
         ```
-- [LuaRocks](https://luarocks.org/), the Lua package manager, to use the Lua API
+
+If you would like to use the Lua API, you will additionally need:
+
+- [Lua](https://www.lua.org/) 5.4 or newer
+- [LuaRocks](https://luarocks.org/), the Lua package manager
     - Arch:
         ```sh
         sudo pacman -S luarocks
@@ -105,11 +105,14 @@ cargo build [--release]
 > - Copy the [Lua default config](api/lua/examples/default) and 
 >   [Rust default config](api/rust/examples/default_config/for_copying) to
 >   `$XDG_DATA_HOME/pinnacle/default_config/{lua,rust}`
-> - `cd` into [`api/lua`](api/lua) and run `luarocks make` to install the Lua library to `~/.luarocks/share/lua/5.4`
 
 # Running
-> [!IMPORTANT]
+> [!TIP]
 > Before running, read the information in [Configuration](#configuration).
+
+> [!IMPORTANT]
+> If you are going to use a Lua config, you must `cd` into [`api/lua`](api/lua)
+> and run `luarocks make [--local]` to install Pinnacle's Lua library.
 
 After building, run the executable located in either:
 ```sh
@@ -128,8 +131,8 @@ See flags you can pass in by running `cargo run -- --help` (or `-h`).
 Pinnacle is configured in your choice of Lua or Rust.
 
 ## Out-of-the-box configurations
-If you just want to test Pinnacle out without copying stuff to your config directory,
-run one of the following in the crate root:
+Pinnacle embeds the default Rust config into the binary. If you would like to use
+the Lua or Rust default configs standalone, run one of the following in the crate root:
 
 ```sh
 # For a Lua configuration
@@ -209,7 +212,7 @@ Rust: https://pinnacle-comp.github.io/rust-reference/main.</b>
 > Documentation for other branches can be reached by replacing `main` with the branch you want.
 
 # Controls
-The following are the default controls in the [`default_config`](api/lua/examples/default/default_config.lua).
+The following are the default controls in the [`default_config`](api/rust/examples/default_config/main.rs).
 | Binding                                      | Action                             |
 |----------------------------------------------|------------------------------------|
 | <kbd>Ctrl</kbd> + <kbd>Mouse left drag</kbd> | Move window                        |

--- a/api/protocol/pinnacle/v0alpha1/pinnacle.proto
+++ b/api/protocol/pinnacle/v0alpha1/pinnacle.proto
@@ -36,8 +36,12 @@ message PingResponse {
   optional bytes payload = 1;
 }
 
+message ShutdownWatchRequest {}
+message ShutdownWatchResponse {}
+
 service PinnacleService {
   rpc Quit(QuitRequest) returns (google.protobuf.Empty);
   rpc ReloadConfig(ReloadConfigRequest) returns (google.protobuf.Empty);
   rpc Ping(PingRequest) returns (PingResponse);
+  rpc ShutdownWatch(ShutdownWatchRequest) returns (stream ShutdownWatchResponse);
 }

--- a/api/rust/src/lib.rs
+++ b/api/rust/src/lib.rs
@@ -75,9 +75,9 @@
 //! ## 5. Begin crafting your config!
 //! You can peruse the documentation for things to configure.
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use futures::{future::BoxFuture, Future, StreamExt};
+use futures::{future::BoxFuture, Future, FutureExt, StreamExt};
 use input::Input;
 use layout::Layout;
 use output::Output;
@@ -179,7 +179,7 @@ pub async fn connect(
     let output = Box::leak(Box::new(Output::new(channel.clone())));
     let tag = Box::leak(Box::new(Tag::new(channel.clone())));
     let render = Box::leak(Box::new(Render::new(channel.clone())));
-    let layout = Box::leak(Box::new(Layout::new(channel.clone())));
+    let layout = Box::leak(Box::new(Layout::new(channel.clone(), fut_sender.clone())));
 
     let modules = ApiModules {
         pinnacle,
@@ -213,25 +213,14 @@ pub async fn listen(api: ApiModules, fut_recv: UnboundedReceiver<BoxFuture<'stat
     let mut fut_recv = UnboundedReceiverStream::new(fut_recv);
     let mut set = futures::stream::FuturesUnordered::new();
 
-    let keepalive = async move {
-        loop {
-            tokio::time::sleep(Duration::from_secs(60)).await;
-            if let Err(err) = api.pinnacle.ping().await {
-                eprintln!("Failed to ping compositor: {err}");
-                panic!("failed to ping compositor");
-            }
-        }
-    };
+    let mut shutdown_stream = api.pinnacle.shutdown_watch().await;
 
-    let mut shutdown_stream = api.pinnacle.shutdown_watch();
-
-    let shutdown_watcher = async move {
+    let mut shutdown_watcher = async move {
+        // This will trigger either when the compositor sends the shutdown signal
+        // or when it exits (in which case the stream received an error)
         shutdown_stream.next().await;
-        panic!("Shutdown received");
-    };
-
-    set.push(tokio::spawn(keepalive));
-    set.push(tokio::spawn(shutdown_watcher));
+    }
+    .boxed();
 
     loop {
         tokio::select! {
@@ -243,10 +232,15 @@ pub async fn listen(api: ApiModules, fut_recv: UnboundedReceiver<BoxFuture<'stat
                 }
             }
             res = set.next() => {
-                match res {
-                    Some(Err(_)) | None => break,
-                    _ => (),
+                if let Some(Err(join_err)) = res {
+                    eprintln!("tokio task panicked: {join_err}");
+                    api.signal.write().await.shutdown();
+                    break;
                 }
+            }
+            _ = &mut shutdown_watcher => {
+                api.signal.write().await.shutdown();
+                break;
             }
         }
     }

--- a/api/rust/src/pinnacle.rs
+++ b/api/rust/src/pinnacle.rs
@@ -10,9 +10,10 @@ use std::time::Duration;
 
 use pinnacle_api_defs::pinnacle::v0alpha1::{
     pinnacle_service_client::PinnacleServiceClient, PingRequest, QuitRequest, ReloadConfigRequest,
+    ShutdownWatchRequest, ShutdownWatchResponse,
 };
 use rand::RngCore;
-use tonic::{transport::Channel, Request};
+use tonic::{transport::Channel, Request, Streaming};
 
 use crate::block_on_tokio;
 
@@ -46,6 +47,13 @@ impl Pinnacle {
     pub fn reload_config(&self) {
         let mut client = self.client.clone();
         block_on_tokio(client.reload_config(ReloadConfigRequest {})).unwrap();
+    }
+
+    pub(crate) fn shutdown_watch(&self) -> Streaming<ShutdownWatchResponse> {
+        let mut client = self.client.clone();
+        block_on_tokio(client.shutdown_watch(ShutdownWatchRequest {}))
+            .unwrap()
+            .into_inner()
     }
 
     pub(super) async fn ping(&self) -> Result<(), String> {

--- a/api/rust/src/pinnacle.rs
+++ b/api/rust/src/pinnacle.rs
@@ -40,22 +40,28 @@ impl Pinnacle {
     /// ```
     pub fn quit(&self) {
         let mut client = self.client.clone();
-        block_on_tokio(client.quit(QuitRequest {})).unwrap();
+        // Ignore errors here, the config is meant to be killed
+        let _ = block_on_tokio(client.quit(QuitRequest {}));
     }
 
     /// Reload the currently active config.
     pub fn reload_config(&self) {
         let mut client = self.client.clone();
-        block_on_tokio(client.reload_config(ReloadConfigRequest {})).unwrap();
+        // Ignore errors here, the config is meant to be killed
+        let _ = block_on_tokio(client.reload_config(ReloadConfigRequest {}));
     }
 
-    pub(crate) fn shutdown_watch(&self) -> Streaming<ShutdownWatchResponse> {
+    pub(crate) async fn shutdown_watch(&self) -> Streaming<ShutdownWatchResponse> {
         let mut client = self.client.clone();
-        block_on_tokio(client.shutdown_watch(ShutdownWatchRequest {}))
+        client
+            .shutdown_watch(ShutdownWatchRequest {})
+            .await
             .unwrap()
             .into_inner()
     }
 
+    /// TODO: eval if this is necessary
+    #[allow(dead_code)]
     pub(super) async fn ping(&self) -> Result<(), String> {
         let mut client = self.client.clone();
         let mut payload = [0u8; 8];

--- a/api/rust/src/signal.rs
+++ b/api/rust/src/signal.rs
@@ -298,6 +298,16 @@ impl SignalState {
         self.window_pointer_leave.api.set(api.clone()).unwrap();
         self.tag_active.api.set(api.clone()).unwrap();
     }
+
+    pub(crate) fn shutdown(&mut self) {
+        self.output_connect.reset();
+        self.output_disconnect.reset();
+        self.output_resize.reset();
+        self.output_move.reset();
+        self.window_pointer_enter.reset();
+        self.window_pointer_leave.reset();
+        self.tag_active.reset();
+    }
 }
 
 #[derive(Default, Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -413,7 +423,7 @@ where
                     }
                 }
                 _dc = dc_ping_recv_fuse => {
-                    control_sender.send(Req::from_control(StreamControl::Disconnect)).expect("send failed");
+                    let _ = control_sender.send(Req::from_control(StreamControl::Disconnect));
                     break;
                 }
             }

--- a/build.rs
+++ b/build.rs
@@ -55,13 +55,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .spawn()?
         .wait()?;
 
-    std::env::set_current_dir("api/lua").unwrap();
-    Command::new("luarocks")
-        .arg("make")
-        .arg("--local")
-        .spawn()
-        .expect("Luarocks is not installed")
-        .wait()?;
-
     Ok(())
 }

--- a/src/api/layout.rs
+++ b/src/api/layout.rs
@@ -53,7 +53,15 @@ impl layout_service_server::LayoutService for LayoutService {
                         }
                     }
                 }
-                Err(err) => tracing::error!("{err}"),
+                Err(err) => {
+                    // Ignore broken pipes here, they have a code of `Unknown`
+                    //
+                    // Silences errors when reloading the config, unfortunately also ignores other
+                    // `Unknown` errors
+                    if err.code() != tonic::Code::Unknown {
+                        tracing::error!("{err}")
+                    }
+                }
             },
             |state, sender, _join_handle| {
                 state.layout_state.layout_request_sender = Some(sender);

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,7 +279,7 @@ impl State {
         let config_dir_clone = config_dir.as_ref().map(|dir| dir.as_ref().to_path_buf());
         let load_default_config = |state: &mut State, reason: &str| {
             match &config_dir_clone {
-                Some(dir) => error!("Unable to load config at {}: {reason}", dir.display()),
+                Some(dir) => warn!("Unable to load config at {}: {reason}", dir.display()),
                 None => panic!(
                     "builtin rust config crashed; this is a bug and you should open an issue"
                 ),
@@ -455,7 +455,6 @@ impl State {
                 std::thread::spawn(move || {
                     info!("Starting builtin Rust config");
                     builtin::run();
-                    info!("Builtin config exited");
                     pinger.ping();
                 });
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ use pinnacle_api_defs::pinnacle::{
     render::v0alpha1::render_service_server::RenderServiceServer,
     signal::v0alpha1::signal_service_server::SignalServiceServer,
     tag::v0alpha1::tag_service_server::TagServiceServer,
-    v0alpha1::pinnacle_service_server::PinnacleServiceServer,
+    v0alpha1::{pinnacle_service_server::PinnacleServiceServer, ShutdownWatchResponse},
     window::v0alpha1::window_service_server::WindowServiceServer,
 };
 use smithay::{
@@ -45,6 +45,17 @@ use crate::{
 };
 
 const DEFAULT_SOCKET_DIR: &str = "/tmp";
+
+mod builtin {
+    include!("../api/rust/examples/default_config/main.rs");
+
+    pub fn run() {
+        main();
+    }
+
+    pub const METACONFIG: &str =
+        include_str!("../api/rust/examples/default_config/metaconfig.toml");
+}
 
 /// The metaconfig struct containing what to run, what envs to run it with, various keybinds, and
 /// the target socket directory.
@@ -172,8 +183,11 @@ pub struct Config {
     /// Saved states when outputs are disconnected
     pub connector_saved_states: HashMap<OutputName, ConnectorSavedState>,
 
-    config_join_handle: Option<JoinHandle<()>>,
+    pub config_join_handle: Option<JoinHandle<()>>,
     config_reload_on_crash_token: Option<RegistrationToken>,
+
+    pub shutdown_sender:
+        Option<tokio::sync::mpsc::UnboundedSender<Result<ShutdownWatchResponse, tonic::Status>>>,
 
     pub no_config: bool,
     config_dir: Option<PathBuf>,
@@ -199,6 +213,13 @@ impl Config {
         self.connector_saved_states.clear();
         if let Some(join_handle) = self.config_join_handle.take() {
             join_handle.abort();
+        }
+        if let Some(shutdown_sender) = self.shutdown_sender.take() {
+            shutdown_sender
+                .send(Ok(
+                    pinnacle_api_defs::pinnacle::v0alpha1::ShutdownWatchResponse {},
+                ))
+                .expect("failed to send shutdown signal to config");
         }
         if let Some(token) = self.config_reload_on_crash_token.take() {
             loop_handle.remove(token);
@@ -248,42 +269,44 @@ impl State {
     /// Start the config in `config_dir`.
     ///
     /// If this method is called while a config is already running, it will be replaced.
-    pub fn start_config(&mut self, config_dir: impl AsRef<Path>) -> anyhow::Result<()> {
-        let mut config_dir = config_dir.as_ref();
+    ///
+    /// If `config_dir` is `None`, the builtin Rust config will be used.
+    pub fn start_config(&mut self, mut config_dir: Option<impl AsRef<Path>>) -> anyhow::Result<()> {
+        if let Some(shutdown_sender) = self.config.shutdown_sender.take() {
+            shutdown_sender
+                .send(Ok(
+                    pinnacle_api_defs::pinnacle::v0alpha1::ShutdownWatchResponse {},
+                ))
+                .expect("failed to send shutdown signal to config");
+        }
 
-        let default_lua_config_dir = self
-            .xdg_base_dirs
-            .get_data_file("default_config")
-            .join("lua");
-
+        let config_dir_clone = config_dir.as_ref().map(|dir| dir.as_ref().to_path_buf());
         let load_default_config = |state: &mut State, reason: &str| {
-            error!(
-                "Unable to load config at {}: {reason}",
-                config_dir.display()
-            );
-            info!("Falling back to default Lua config");
-            state.start_config(&default_lua_config_dir)
+            match &config_dir_clone {
+                Some(dir) => error!("Unable to load config at {}: {reason}", dir.display()),
+                None => panic!(
+                    "builtin rust config crashed; this is a bug and you should open an issue"
+                ),
+            }
+
+            info!("Falling back to builtin Rust config");
+            state.start_config(None::<PathBuf>)
         };
 
         // If `--no-config` was set, still load the keybinds from the default metaconfig
         if self.config.no_config {
-            config_dir = &default_lua_config_dir
+            config_dir = None;
         }
 
-        let metaconfig = match parse_metaconfig(config_dir) {
-            Ok(metaconfig) => metaconfig,
-            Err(err) => {
-                // Stops infinite recursion if somehow the default_config dir is screwed up
-                if config_dir == default_lua_config_dir {
-                    error!("The metaconfig at the default Lua config directory is either malformed or missing.");
-                    error!(
-                        "If you have not touched {}, this is a bug and you should file an issue (pretty please with a cherry on top?).",
-                        default_lua_config_dir.display()
-                    );
-                    anyhow::bail!("default lua config dir does not work");
+        let metaconfig = match &config_dir {
+            Some(dir) => match parse_metaconfig(dir.as_ref()) {
+                Ok(metaconfig) => metaconfig,
+                Err(err) => {
+                    return load_default_config(self, &format!("{}, {}", err, err.root_cause()));
                 }
-                return load_default_config(self, &format!("{}, {}", err, err.root_cause()));
-            }
+            },
+            None => toml::from_str(builtin::METACONFIG)
+                .expect("builtin metaconfig was malformed; this is a bug"),
         };
 
         // Clear state
@@ -320,13 +343,14 @@ impl State {
             return Ok(());
         }
 
-        assert!(!self.config.no_config);
-
         // Because the grpc server is implemented to only start once,
         // any updates to `socket_dir` won't be applied until restart.
         if self.grpc_server_join_handle.is_none() {
             // If a socket is provided in the metaconfig, use it.
             let socket_dir = if let Some(socket_dir) = &metaconfig.socket_dir {
+                let Some(config_dir) = &config_dir else {
+                    panic!("builtin config should not have `socket_dir` set");
+                };
                 let socket_dir = shellexpand::full(socket_dir)?.to_string();
 
                 // cd into the metaconfig dir and canonicalize to preserve relative paths
@@ -348,77 +372,99 @@ impl State {
             self.start_grpc_server(socket_dir.as_path())?;
         }
 
-        let mut command = metaconfig.command.iter();
+        match &config_dir {
+            Some(config_dir) => {
+                let config_dir = config_dir.as_ref();
+                let mut command = metaconfig.command.iter();
 
-        let arg0 = match command.next() {
-            Some(arg0) => arg0,
-            None => return load_default_config(self, "no command specified"),
-        };
+                let arg0 = match command.next() {
+                    Some(arg0) => arg0,
+                    None => return load_default_config(self, "no command specified"),
+                };
 
-        let command = command.collect::<Vec<_>>();
+                let command = command.collect::<Vec<_>>();
 
-        debug!(arg0, ?command);
+                debug!(arg0, ?command);
 
-        let envs = metaconfig
-            .envs
-            .unwrap_or(toml::map::Map::new())
-            .into_iter()
-            .map(|(key, val)| -> anyhow::Result<Option<(String, String)>> {
-                if let toml::Value::String(string) = val {
-                    Ok(Some((key, shellexpand::full(&string)?.to_string())))
-                } else {
-                    Ok(None)
-                }
-            })
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .flatten();
+                let envs = metaconfig
+                    .envs
+                    .unwrap_or(toml::map::Map::new())
+                    .into_iter()
+                    .map(|(key, val)| -> anyhow::Result<Option<(String, String)>> {
+                        if let toml::Value::String(string) = val {
+                            Ok(Some((key, shellexpand::full(&string)?.to_string())))
+                        } else {
+                            Ok(None)
+                        }
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
+                    .flatten();
 
-        debug!("Config envs are {envs:?}");
+                debug!("Config envs are {envs:?}");
 
-        info!(
-            "Starting config process at {} with {:?}",
-            config_dir.display(),
-            metaconfig.command
-        );
+                info!(
+                    "Starting config process at {} with {:?}",
+                    config_dir.display(),
+                    metaconfig.command
+                );
 
-        let mut cmd = tokio::process::Command::new(arg0);
-        cmd.args(command)
-            .envs(envs)
-            .current_dir(config_dir)
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .kill_on_drop(true);
+                let mut cmd = tokio::process::Command::new(arg0);
+                cmd.args(command)
+                    .envs(envs)
+                    .current_dir(config_dir)
+                    .stdout(Stdio::inherit())
+                    .stderr(Stdio::inherit())
+                    .kill_on_drop(true);
 
-        let mut child = match cmd.spawn() {
-            Ok(child) => child,
-            Err(err) => {
-                return load_default_config(
-                    self,
-                    &format!("failed to start config process {cmd:?}: {err}"),
-                )
+                let mut child = match cmd.spawn() {
+                    Ok(child) => child,
+                    Err(err) => {
+                        return load_default_config(
+                            self,
+                            &format!("failed to start config process {cmd:?}: {err}"),
+                        )
+                    }
+                };
+
+                info!("Started config with {:?}", metaconfig.command);
+
+                let (pinger, ping_source) = calloop::ping::make_ping()?;
+
+                let token = self
+                    .loop_handle
+                    .insert_source(ping_source, move |_, _, state| {
+                        error!("Config crashed! Falling back to default Lua config");
+                        state
+                            .start_config(None::<PathBuf>)
+                            .expect("failed to start default config");
+                    })?;
+
+                self.config.config_join_handle = Some(tokio::spawn(async move {
+                    let _ = child.wait().await;
+                    pinger.ping();
+                }));
+
+                self.config.config_reload_on_crash_token = Some(token);
             }
-        };
+            None => {
+                let (pinger, ping_source) = calloop::ping::make_ping()?;
 
-        info!("Started config with {:?}", metaconfig.command);
+                let token = self
+                    .loop_handle
+                    .insert_source(ping_source, move |_, _, _state| {
+                        panic!("builtin rust config crashed; this is a bug");
+                    })?;
 
-        let (pinger, ping_source) = calloop::ping::make_ping()?;
+                self.config.config_join_handle = Some(tokio::task::spawn_blocking(move || {
+                    info!("Starting builtin Rust config");
+                    builtin::run();
+                    pinger.ping();
+                }));
 
-        let token = self
-            .loop_handle
-            .insert_source(ping_source, move |_, _, state| {
-                error!("Config crashed! Falling back to default Lua config");
-                state
-                    .start_config(&default_lua_config_dir)
-                    .expect("failed to start default lua config");
-            })?;
-
-        self.config.config_join_handle = Some(tokio::spawn(async move {
-            let _ = child.wait().await;
-            pinger.ping();
-        }));
-
-        self.config.config_reload_on_crash_token = Some(token);
+                self.config.config_reload_on_crash_token = Some(token);
+            }
+        }
 
         Ok(())
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -427,7 +427,7 @@ impl State {
                 self.shutdown();
             }
             Some(KeyAction::ReloadConfig) => {
-                self.start_config(self.config.dir(&self.xdg_base_dirs))
+                self.start_config(Some(self.config.dir(&self.xdg_base_dirs)))
                     .expect("failed to restart config");
             }
             None => (),

--- a/src/input.rs
+++ b/src/input.rs
@@ -31,6 +31,7 @@ use smithay::{
     },
 };
 use tokio::sync::mpsc::UnboundedSender;
+use tracing::info;
 use xkbcommon::xkb::Keysym;
 
 use crate::state::State;
@@ -427,6 +428,7 @@ impl State {
                 self.shutdown();
             }
             Some(KeyAction::ReloadConfig) => {
+                info!("Reloading config");
                 self.start_config(Some(self.config.dir(&self.xdg_base_dirs)))
                     .expect("failed to restart config");
             }

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,6 +12,7 @@ use crate::{
     window::WindowElement,
 };
 use anyhow::Context;
+use pinnacle_api_defs::pinnacle::v0alpha1::ShutdownWatchResponse;
 use smithay::{
     desktop::{PopupManager, Space},
     input::{keyboard::XkbConfig, pointer::CursorImageStatus, Seat, SeatState},
@@ -43,7 +44,7 @@ use smithay::{
 };
 use std::{cell::RefCell, path::PathBuf, sync::Arc, time::Duration};
 use sysinfo::{ProcessRefreshKind, RefreshKind};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use xdg::BaseDirectories;
 
 use crate::input::InputState;
@@ -332,11 +333,9 @@ impl State {
             join_handle.abort();
         }
         if let Some(shutdown_sender) = self.config.shutdown_sender.take() {
-            shutdown_sender
-                .send(Ok(
-                    pinnacle_api_defs::pinnacle::v0alpha1::ShutdownWatchResponse {},
-                ))
-                .expect("failed to send shutdown signal to config");
+            if let Err(err) = shutdown_sender.send(Ok(ShutdownWatchResponse {})) {
+                warn!("Failed to send shutdown signal to config: {err}");
+            }
         }
     }
 }


### PR DESCRIPTION
This PR embeds the default Rust config into the binary, meaning that Pinnacle no longer needs to run a separate process for the default config. It removes the hard dependency on Luarocks. This is halfway to resolving #214 and unblocking #215; the other half is to create a Makefile or some other external runner to copy over protobuf definitions and default configs for `pinnacle config gen`, but that's for another PR/commit.

This *does* mean that users who want to use the Lua API will need to manually `cd` into [`api/lua`](https://github.com/pinnacle-comp/pinnacle/tree/main/api/lua) and run `luarocks make [--local]`. Edit: Or stick that in the Makefile maybe idk my brain's fried rn

Also build times went up by like 9% :P. I considered locking the embedding behind a feature flag to mitigate this for Lua users, but I think it's cleaner if Pinnacle doesn't hard require a separate process and library to run.

TODO:
- [x] Fix how the Rust API handles tokio task panics
    - Currently all tokio tasks panic if something goes wrong. Also the shutdown watcher task panics as well because everything needs to have the same return value. Goal is to make all futures return a Result or something instead of panicking.
        - Nvm lol we ballin', turns out there was an issue with a tokio task not exiting correctly
- [x] The layout receiver keeps erroring when the config is reloaded, should probably ~~`Option::take` the receiver when reloading the config to drop it~~ ignore the error? idk
- [x] Remove the Luarocks make from `build.rs`
    - Removing the rest of the build script is for the future PR/commit
- [x] Test running various configs and `--no-config`