### PR TITLE
Better output management

### DIFF
--- a/.github/workflows/ci.pinnacle.yml
+++ b/.github/workflows/ci.pinnacle.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Cache stuff
         uses: Swatinem/rust-cache@v2
       - name: Get dependencies
-        run: sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev liblua5.4-dev libdisplay-info-dev
+        run: sudo apt remove needrestart && sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev liblua5.4-dev libdisplay-info-dev
       - name: Setup Lua
         uses: leafo/gh-actions-lua@v10
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Cache stuff
         uses: Swatinem/rust-cache@v2
       - name: Get dependencies
-        run: sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev foot liblua5.4-dev libdisplay-info-dev
+        run: sudo apt remove needrestart && sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev foot liblua5.4-dev libdisplay-info-dev
       - name: Setup Lua
         uses: leafo/gh-actions-lua@v10
         with:
@@ -84,7 +84,7 @@ jobs:
       - name: Cache stuff
         uses: Swatinem/rust-cache@v2
       - name: Get dependencies
-        run: sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev liblua5.4-dev libdisplay-info-dev
+        run: sudo apt remove needrestart && sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev liblua5.4-dev libdisplay-info-dev
       - name: Setup Lua
         uses: leafo/gh-actions-lua@v10
         with:

--- a/.github/workflows/ci.pinnacle.yml
+++ b/.github/workflows/ci.pinnacle.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Build
     steps:
       - name: Checkout
@@ -34,7 +34,7 @@ jobs:
       - name: Celebratory yahoo
         run: echo yahoo
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Run tests
     steps:
       - name: Checkout
@@ -60,7 +60,7 @@ jobs:
         if: ${{ runner.debug == '1' }}
         run: RUST_LOG=debug RUST_BACKTRACE=1 just install test -- --nocapture --test-threads=1
   check-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Check formatting
     steps:
       - name: Checkout
@@ -72,7 +72,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
   clippy-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Clippy check
     steps:
       - name: Checkout

--- a/.github/workflows/ci.pinnacle.yml
+++ b/.github/workflows/ci.pinnacle.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Cache stuff
         uses: Swatinem/rust-cache@v2
       - name: Get dependencies
-        run: sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev liblua5.4-dev
+        run: sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev liblua5.4-dev libdisplay-info-dev
       - name: Setup Lua
         uses: leafo/gh-actions-lua@v10
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Cache stuff
         uses: Swatinem/rust-cache@v2
       - name: Get dependencies
-        run: sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev foot liblua5.4-dev
+        run: sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev foot liblua5.4-dev libdisplay-info-dev
       - name: Setup Lua
         uses: leafo/gh-actions-lua@v10
         with:
@@ -84,7 +84,7 @@ jobs:
       - name: Cache stuff
         uses: Swatinem/rust-cache@v2
       - name: Get dependencies
-        run: sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev liblua5.4-dev
+        run: sudo apt update && sudo apt install libwayland-dev libxkbcommon-dev libudev-dev libinput-dev libgbm-dev libseat-dev libsystemd-dev protobuf-compiler xwayland libegl-dev liblua5.4-dev libdisplay-info-dev
       - name: Setup Lua
         uses: leafo/gh-actions-lua@v10
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
+name = "libdisplay-info-sys"
+version = "0.1.0"
+source = "git+https://github.com/Smithay/libdisplay-info-rs?rev=a482d0d#a482d0d4b71762c13d40fa394efe04473916f31c"
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,8 +1856,10 @@ dependencies = [
  "clap",
  "cliclack",
  "dircpy",
+ "drm-sys",
  "gag",
  "image",
+ "libdisplay-info-sys",
  "pinnacle",
  "pinnacle-api",
  "pinnacle-api-defs",
@@ -2381,7 +2388,6 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay/smithay?rev=900b938#900b938970081cb525dc94ff083d76aa07c60e54"
 dependencies = [
  "appendlist",
  "ash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,6 +1859,7 @@ dependencies = [
  "drm-sys",
  "gag",
  "image",
+ "indexmap 2.2.6",
  "libdisplay-info-sys",
  "pinnacle",
  "pinnacle-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,6 +2388,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smithay"
 version = "0.3.0"
+source = "git+https://github.com/Smithay/smithay?rev=900b938#900b938970081cb525dc94ff083d76aa07c60e54"
 dependencies = [
  "appendlist",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ pinnacle-api = { path = "./api/rust" }
 gag = "1.0.0"
 drm-sys = "0.7.0"
 libdisplay-info-sys = { git = "https://github.com/Smithay/libdisplay-info-rs", rev = "a482d0d" }
+indexmap = "2.2.6"
 
 [build-dependencies]
 vergen = { version = "8.3.1", features = ["git", "gitcl", "rustc", "cargo", "si"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ dircpy = "0.3.16"
 tempfile = "3.10.1"
 
 [workspace.dependencies.smithay]
-git = "https://github.com/Smithay/smithay"
-rev = "900b938"
-# path = "../../git/smithay"
+# git = "https://github.com/Smithay/smithay"
+# rev = "900b938"
+path = "../../git/smithay"
 default-features = false
 features = [
     "desktop",
@@ -115,6 +115,8 @@ chrono = "0.4.38"
 bytemuck = "1.16.0"
 pinnacle-api = { path = "./api/rust" }
 gag = "1.0.0"
+drm-sys = "0.7.0"
+libdisplay-info-sys = { git = "https://github.com/Smithay/libdisplay-info-rs", rev = "a482d0d" }
 
 [build-dependencies]
 vergen = { version = "8.3.1", features = ["git", "gitcl", "rustc", "cargo", "si"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ dircpy = "0.3.16"
 tempfile = "3.10.1"
 
 [workspace.dependencies.smithay]
-# git = "https://github.com/Smithay/smithay"
-# rev = "900b938"
-path = "../../git/smithay"
+git = "https://github.com/Smithay/smithay"
+rev = "900b938"
+# path = "../../git/smithay"
 default-features = false
 features = [
     "desktop",

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ You will need:
       `LD_LIBRARY_PATH` so the dynamically loaded libraries are found.
       > Luarocks currently doesn't install the Lua library and its dependencies due to openssh directory
       > shenanigans. Fix soon, hopefully. In the meantime you can use the Rust API.
+- `libdisplay-info`, for monitor display information
 - [protoc](https://grpc.io/docs/protoc-installation/), the Protocol Buffer Compiler, for configuration
     - Arch:
         ```sh

--- a/api/lua/pinnacle/grpc/defs.lua
+++ b/api/lua/pinnacle/grpc/defs.lua
@@ -65,6 +65,20 @@ local pinnacle_output_v0alpha1_Transform = {
 ---@field pixel_height integer?
 ---@field refresh_rate_millihz integer?
 
+---@class pinnacle.output.v0alpha1.SetModelineRequest
+---@field output_name string?
+---@field clock number?
+---@field hdisplay integer?
+---@field hsync_start integer?
+---@field hsync_end integer?
+---@field htotal integer?
+---@field vdisplay integer?
+---@field vsync_start integer?
+---@field vsync_end integer?
+---@field vtotal integer?
+---@field hsync_pos boolean?
+---@field vsync_pos boolean?
+
 ---@class pinnacle.output.v0alpha1.SetScaleRequest
 ---@field output_name string?
 ---@field absolute number?
@@ -473,6 +487,13 @@ defs.pinnacle = {
                     service = "pinnacle.output.v0alpha1.OutputService",
                     method = "SetMode",
                     request = "pinnacle.output.v0alpha1.SetModeRequest",
+                    response = "google.protobuf.Empty",
+                },
+                ---@type GrpcRequestArgs
+                SetModeline = {
+                    service = "pinnacle.output.v0alpha1.OutputService",
+                    method = "SetModeline",
+                    request = "pinnacle.output.v0alpha1.SetModelineRequest",
                     response = "google.protobuf.Empty",
                 },
                 ---@type GrpcRequestArgs

--- a/api/lua/pinnacle/grpc/defs.lua
+++ b/api/lua/pinnacle/grpc/defs.lua
@@ -118,6 +118,8 @@ local pinnacle_output_v0alpha1_Transform = {
 ---@field transform pinnacle.output.v0alpha1.Transform?
 ---@field serial integer?
 ---@field keyboard_focus_stack_window_ids integer[]?
+---@field enabled boolean?
+---@field powered boolean?
 
 -- Window
 

--- a/api/lua/pinnacle/output.lua
+++ b/api/lua/pinnacle/output.lua
@@ -163,6 +163,7 @@ end
 ---@class OutputSetup
 ---@field filter (fun(output: OutputHandle): boolean)? -- A filter for wildcard matches that should return true if this setup should apply to the passed in output.
 ---@field mode Mode? -- Makes this setup apply the given mode to outputs.
+---@field modeline (string|Modeline)? -- Makes this setup apply the given modeline to outputs. This takes precedence over `mode`.
 ---@field scale number? -- Makes this setup apply the given scale to outputs.
 ---@field tags string[]? -- Makes this setup add tags with the given name to outputs.
 ---@field transform Transform? -- Makes this setup applt the given transform to outputs.
@@ -289,7 +290,9 @@ function output.setup(setups)
                     goto continue
                 end
 
-                if setup.mode then
+                if setup.modeline then
+                    op:set_modeline(setup.modeline)
+                elseif setup.mode then
                     op:set_mode(
                         setup.mode.pixel_width,
                         setup.mode.pixel_height,

--- a/api/lua/pinnacle/output.lua
+++ b/api/lua/pinnacle/output.lua
@@ -813,6 +813,54 @@ function OutputHandle:set_mode(pixel_width, pixel_height, refresh_rate_millihz)
     })
 end
 
+---@class Modeline
+---@field clock number
+---@field hdisplay integer
+---@field hsync_start integer
+---@field hsync_end integer
+---@field htotal integer
+---@field vdisplay integer
+---@field vsync_start integer
+---@field vsync_end integer
+---@field vtotal integer
+---@field hsync boolean
+---@field vsync boolean
+
+---Set a custom modeline for this output.
+---
+---This accepts a `Modeline` table or a string of the modeline.
+---
+---@param modeline string|Modeline
+function OutputHandle:set_modeline(modeline)
+    if type(modeline) == "string" then
+        local ml, err = require("pinnacle.util").output.parse_modeline(modeline)
+        if ml then
+            modeline = ml
+        else
+            print("invalid modeline: " .. tostring(err))
+            return
+        end
+    end
+
+    ---@type pinnacle.output.v0alpha1.SetModelineRequest
+    local request = {
+        output_name = self.name,
+        clock = modeline.clock,
+        hdisplay = modeline.hdisplay,
+        hsync_start = modeline.hsync_start,
+        hsync_end = modeline.hsync_end,
+        htotal = modeline.htotal,
+        vdisplay = modeline.vdisplay,
+        vsync_start = modeline.vsync_start,
+        vsync_end = modeline.vsync_end,
+        vtotal = modeline.vtotal,
+        hsync_pos = modeline.hsync,
+        vsync_pos = modeline.vsync,
+    }
+
+    client.unary_request(output_service.SetModeline, request)
+end
+
 ---Set this output's scaling factor.
 ---
 ---@param scale number

--- a/api/lua/pinnacle/util.lua
+++ b/api/lua/pinnacle/util.lua
@@ -118,10 +118,93 @@ function rectangle.new(x, y, width, height)
     return self
 end
 
+---Parse a modeline string.
+---
+---@param modeline string
+---
+---@return Modeline|nil modeline A modeline if successful
+---@return string|nil error An error message if any
+local function parse_modeline(modeline)
+    local args = modeline:gmatch("[^%s]+")
+
+    local targs = {}
+
+    for arg in args do
+        table.insert(targs, arg)
+    end
+
+    local clock = tonumber(targs[1])
+    local hdisplay = tonumber(targs[2])
+    local hsync_start = tonumber(targs[3])
+    local hsync_end = tonumber(targs[4])
+    local htotal = tonumber(targs[5])
+    local vdisplay = tonumber(targs[6])
+    local vsync_start = tonumber(targs[7])
+    local vsync_end = tonumber(targs[8])
+    local vtotal = tonumber(targs[9])
+    local hsync = targs[10]
+    local vsync = targs[11]
+
+    if
+        not (
+            clock
+            and hdisplay
+            and hsync_start
+            and hsync_end
+            and htotal
+            and vdisplay
+            and vsync_start
+            and vsync_end
+            and vtotal
+            and hsync
+            and vsync
+        )
+    then
+        return nil, "one or more fields was missing"
+    end
+
+    local hsync_lower = string.lower(hsync)
+    local vsync_lower = string.lower(vsync)
+
+    if hsync_lower == "+hsync" then
+        hsync = true
+    elseif hsync_lower == "-hsync" then
+        hsync = false
+    else
+        return nil, "invalid hsync: " .. hsync
+    end
+
+    if vsync_lower == "+vsync" then
+        vsync = true
+    elseif vsync_lower == "-vsync" then
+        vsync = false
+    else
+        return nil, "invalid vsync: " .. vsync
+    end
+
+    ---@type Modeline
+    return {
+        clock = clock,
+        hdisplay = hdisplay,
+        hsync_start = hsync_start,
+        hsync_end = hsync_end,
+        htotal = htotal,
+        vdisplay = vdisplay,
+        vsync_start = vsync_start,
+        vsync_end = vsync_end,
+        vtotal = vtotal,
+        hsync = hsync,
+        vsync = vsync,
+    }
+end
+
 ---Utility functions.
 ---@class Util
 local util = {
     rectangle = rectangle,
+    output = {
+        parse_modeline = parse_modeline,
+    },
 }
 
 ---Batch a set of requests that will be sent to the compositor all at once.

--- a/api/protocol/pinnacle/output/v0alpha1/output.proto
+++ b/api/protocol/pinnacle/output/v0alpha1/output.proto
@@ -36,6 +36,21 @@ message SetModeRequest {
   optional uint32 refresh_rate_millihz = 4;
 }
 
+message SetModelineRequest {
+  optional string output_name = 1;
+  optional float clock = 2;
+  optional uint32 hdisplay = 3;
+  optional uint32 hsync_start = 4;
+  optional uint32 hsync_end = 5;
+  optional uint32 htotal = 6;
+  optional uint32 vdisplay = 7;
+  optional uint32 vsync_start = 8;
+  optional uint32 vsync_end = 9;
+  optional uint32 vtotal = 10;
+  optional bool hsync_pos = 11;
+  optional bool vsync_pos = 12;
+}
+
 message SetScaleRequest {
   optional string output_name = 1;
   oneof absolute_or_relative {
@@ -106,6 +121,7 @@ message GetPropertiesResponse {
 service OutputService {
   rpc SetLocation(SetLocationRequest) returns (google.protobuf.Empty);
   rpc SetMode(SetModeRequest) returns (google.protobuf.Empty);
+  rpc SetModeline(SetModelineRequest) returns (google.protobuf.Empty);
   rpc SetScale(SetScaleRequest) returns (google.protobuf.Empty);
   rpc SetTransform(SetTransformRequest) returns (google.protobuf.Empty);
   rpc SetPowered(SetPoweredRequest) returns (google.protobuf.Empty);

--- a/api/protocol/pinnacle/output/v0alpha1/output.proto
+++ b/api/protocol/pinnacle/output/v0alpha1/output.proto
@@ -116,6 +116,8 @@ message GetPropertiesResponse {
   optional uint32 serial = 16;
   // Window ids of the keyboard focus stack for this output.
   repeated uint32 keyboard_focus_stack_window_ids = 17;
+  optional bool enabled = 18;
+  optional bool powered = 19;
 }
 
 service OutputService {

--- a/src/api.rs
+++ b/src/api.rs
@@ -1070,6 +1070,7 @@ impl output_service_server::OutputService for OutputService {
             let Some(mode) = Some(request).and_then(|request| {
                 Some(smithay::output::Mode {
                     size: (request.pixel_width? as i32, request.pixel_height? as i32).into(),
+                    // FIXME: this is nullable, pick a mode with highest refresh if None
                     refresh: request.refresh_rate_millihz? as i32,
                 })
             }) else {

--- a/src/api.rs
+++ b/src/api.rs
@@ -1035,9 +1035,14 @@ impl output_service_server::OutputService for OutputService {
             if let Some(y) = y {
                 loc.y = y;
             }
-            state
-                .pinnacle
-                .change_output_state(&output, None, None, None, Some(loc));
+            state.pinnacle.change_output_state(
+                &mut state.backend,
+                &output,
+                None,
+                None,
+                None,
+                Some(loc),
+            );
             debug!("Mapping output {} to {loc:?}", output.name());
             state.pinnacle.request_layout(&output);
         })
@@ -1067,7 +1072,15 @@ impl output_service_server::OutputService for OutputService {
                 return;
             };
 
-            state.resize_output(&output, mode);
+            state.pinnacle.change_output_state(
+                &mut state.backend,
+                &output,
+                Some(mode),
+                None,
+                None,
+                None,
+            );
+            state.pinnacle.request_layout(&output);
         })
         .await
     }
@@ -1102,6 +1115,7 @@ impl output_service_server::OutputService for OutputService {
             });
 
             state.pinnacle.change_output_state(
+                &mut state.backend,
                 &output,
                 None,
                 None,
@@ -1154,9 +1168,14 @@ impl output_service_server::OutputService for OutputService {
                 return;
             };
 
-            state
-                .pinnacle
-                .change_output_state(&output, None, Some(smithay_transform), None, None);
+            state.pinnacle.change_output_state(
+                &mut state.backend,
+                &output,
+                None,
+                Some(smithay_transform),
+                None,
+                None,
+            );
             state.pinnacle.request_layout(&output);
             state.schedule_render(&output);
         })

--- a/src/api.rs
+++ b/src/api.rs
@@ -1045,6 +1045,10 @@ impl output_service_server::OutputService for OutputService {
             );
             debug!("Mapping output {} to {loc:?}", output.name());
             state.pinnacle.request_layout(&output);
+            state
+                .pinnacle
+                .output_management_manager_state
+                .update::<State>();
         })
         .await
     }
@@ -1081,6 +1085,10 @@ impl output_service_server::OutputService for OutputService {
                 None,
             );
             state.pinnacle.request_layout(&output);
+            state
+                .pinnacle
+                .output_management_manager_state
+                .update::<State>();
         })
         .await
     }
@@ -1135,6 +1143,10 @@ impl output_service_server::OutputService for OutputService {
 
             state.pinnacle.request_layout(&output);
             state.schedule_render(&output);
+            state
+                .pinnacle
+                .output_management_manager_state
+                .update::<State>();
         })
         .await
     }
@@ -1178,6 +1190,10 @@ impl output_service_server::OutputService for OutputService {
             );
             state.pinnacle.request_layout(&output);
             state.schedule_render(&output);
+            state
+                .pinnacle
+                .output_management_manager_state
+                .update::<State>();
         })
         .await
     }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -34,6 +34,7 @@ use smithay::{
 use tracing::error;
 
 use crate::{
+    output::OutputMode,
     state::{Pinnacle, State, SurfaceDmabufFeedback, WithState},
     window::WindowElement,
 };
@@ -152,7 +153,7 @@ pub trait BackendData: 'static {
     // INFO: only for udev in anvil, maybe shouldn't be a trait fn?
     fn early_import(&mut self, surface: &WlSurface);
 
-    fn set_output_mode(&mut self, output: &Output, mode: smithay::output::Mode);
+    fn set_output_mode(&mut self, output: &Output, mode: OutputMode);
 }
 
 impl BackendData for Backend {
@@ -183,7 +184,7 @@ impl BackendData for Backend {
         }
     }
 
-    fn set_output_mode(&mut self, output: &Output, mode: smithay::output::Mode) {
+    fn set_output_mode(&mut self, output: &Output, mode: OutputMode) {
         match self {
             Backend::Winit(winit) => winit.set_output_mode(output, mode),
             Backend::Udev(udev) => udev.set_output_mode(output, mode),

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -151,6 +151,8 @@ pub trait BackendData: 'static {
 
     // INFO: only for udev in anvil, maybe shouldn't be a trait fn?
     fn early_import(&mut self, surface: &WlSurface);
+
+    fn set_output_mode(&mut self, output: &Output, mode: smithay::output::Mode);
 }
 
 impl BackendData for Backend {
@@ -178,6 +180,15 @@ impl BackendData for Backend {
             Backend::Udev(udev) => udev.early_import(surface),
             #[cfg(feature = "testing")]
             Backend::Dummy(dummy) => dummy.early_import(surface),
+        }
+    }
+
+    fn set_output_mode(&mut self, output: &Output, mode: smithay::output::Mode) {
+        match self {
+            Backend::Winit(winit) => winit.set_output_mode(output, mode),
+            Backend::Udev(udev) => udev.set_output_mode(output, mode),
+            #[cfg(feature = "testing")]
+            Backend::Dummy(dummy) => dummy.set_output_mode(output, mode),
         }
     }
 }

--- a/src/backend/dummy.rs
+++ b/src/backend/dummy.rs
@@ -95,9 +95,11 @@ impl Dummy {
         UninitBackend {
             seat_name: dummy.seat_name(),
             init: Box::new(move |pinnacle| {
-                output.create_global::<State>(&display_handle);
+                let global = output.create_global::<State>(&display_handle);
 
                 pinnacle.output_focus_stack.set_focus(output.clone());
+
+                pinnacle.outputs.insert(output.clone(), Some(global));
 
                 pinnacle
                     .shm_state
@@ -136,7 +138,9 @@ impl Pinnacle {
         output.set_preferred(mode);
         output.with_state_mut(|state| state.modes = vec![mode]);
 
-        output.create_global::<State>(&self.display_handle);
+        let global = output.create_global::<State>(&self.display_handle);
+
+        self.outputs.insert(output.clone(), Some(global));
 
         self.space.map_output(&output, (0, 0));
 

--- a/src/backend/dummy.rs
+++ b/src/backend/dummy.rs
@@ -1,6 +1,4 @@
-use pinnacle_api_defs::pinnacle::signal::v0alpha1::{
-    OutputConnectResponse, OutputDisconnectResponse,
-};
+use pinnacle_api_defs::pinnacle::signal::v0alpha1::OutputConnectResponse;
 use smithay::backend::renderer::test::DummyRenderer;
 use smithay::backend::renderer::ImportMemWl;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
@@ -50,6 +48,10 @@ impl BackendData for Dummy {
     fn reset_buffers(&mut self, _output: &Output) {}
 
     fn early_import(&mut self, _surface: &WlSurface) {}
+
+    fn set_output_mode(&mut self, _output: &Output, _mode: smithay::output::Mode) {
+        // TODO:
+    }
 }
 
 impl Dummy {
@@ -139,16 +141,6 @@ impl Pinnacle {
             buf.push_back(OutputConnectResponse {
                 output_name: Some(output.name()),
             });
-        });
-    }
-
-    pub fn remove_output(&mut self, output: &Output) {
-        self.space.unmap_output(output);
-
-        self.signal_state.output_disconnect.signal(|buffer| {
-            buffer.push_back(OutputDisconnectResponse {
-                output_name: Some(output.name()),
-            })
         });
     }
 }

--- a/src/backend/dummy.rs
+++ b/src/backend/dummy.rs
@@ -28,6 +28,7 @@ pub struct Dummy {
     // pub dmabuf_state: (DmabufState, DmabufGlobal, Option<DmabufFeedback>),
     #[cfg(feature = "wlcs")]
     pub wlcs_state: Wlcs,
+    pub output: Output,
 }
 
 impl Backend {
@@ -49,8 +50,8 @@ impl BackendData for Dummy {
 
     fn early_import(&mut self, _surface: &WlSurface) {}
 
-    fn set_output_mode(&mut self, _output: &Output, _mode: smithay::output::Mode) {
-        // TODO:
+    fn set_output_mode(&mut self, output: &Output, mode: smithay::output::Mode) {
+        output.change_current_state(Some(mode), None, None, None);
     }
 }
 
@@ -87,6 +88,7 @@ impl Dummy {
             // dmabuf_state,
             #[cfg(feature = "wlcs")]
             wlcs_state: Wlcs::default(),
+            output: output.clone(),
         };
 
         UninitBackend {

--- a/src/backend/dummy.rs
+++ b/src/backend/dummy.rs
@@ -10,6 +10,7 @@ use smithay::{
     utils::Transform,
 };
 
+use crate::output::OutputMode;
 use crate::state::{Pinnacle, State, WithState};
 
 use super::BackendData;
@@ -50,8 +51,8 @@ impl BackendData for Dummy {
 
     fn early_import(&mut self, _surface: &WlSurface) {}
 
-    fn set_output_mode(&mut self, output: &Output, mode: smithay::output::Mode) {
-        output.change_current_state(Some(mode), None, None, None);
+    fn set_output_mode(&mut self, output: &Output, mode: OutputMode) {
+        output.change_current_state(Some(mode.into()), None, None, None);
     }
 }
 

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -1055,6 +1055,10 @@ impl Udev {
         );
         let global = output.create_global::<State>(&self.display_handle);
 
+        pinnacle
+            .output_management_manager_state
+            .add_head::<State>(&output);
+
         output.with_state_mut(|state| state.serial = serial);
 
         output.set_preferred(wl_mode);
@@ -1215,6 +1219,10 @@ impl Udev {
                     output_name: Some(output.name()),
                 })
             });
+
+            pinnacle
+                .output_management_manager_state
+                .remove_head(&output);
         }
     }
 

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -36,7 +36,7 @@ use smithay::{
 use tracing::{debug, error, trace, warn};
 
 use crate::{
-    output::BlankingState,
+    output::{BlankingState, OutputMode},
     render::{
         pointer::PointerElement, pointer_render_elements, take_presentation_feedback, CLEAR_COLOR,
         CLEAR_COLOR_LOCKED,
@@ -68,8 +68,8 @@ impl BackendData for Winit {
 
     fn early_import(&mut self, _surface: &WlSurface) {}
 
-    fn set_output_mode(&mut self, output: &Output, mode: smithay::output::Mode) {
-        output.change_current_state(Some(mode), None, None, None);
+    fn set_output_mode(&mut self, output: &Output, mode: OutputMode) {
+        output.change_current_state(Some(mode.into()), None, None, None);
     }
 }
 
@@ -207,7 +207,7 @@ impl Winit {
                             state.pinnacle.change_output_state(
                                 &mut state.backend,
                                 &output,
-                                Some(mode),
+                                Some(OutputMode::Smithay(mode)),
                                 None,
                                 Some(Scale::Fractional(scale_factor)),
                                 // None,

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -67,6 +67,10 @@ impl BackendData for Winit {
     }
 
     fn early_import(&mut self, _surface: &WlSurface) {}
+
+    fn set_output_mode(&mut self, output: &Output, mode: smithay::output::Mode) {
+        output.change_current_state(Some(mode), None, None, None);
+    }
 }
 
 impl Backend {
@@ -201,6 +205,7 @@ impl Winit {
                                 refresh: 144_000,
                             };
                             state.pinnacle.change_output_state(
+                                &mut state.backend,
                                 &output,
                                 Some(mode),
                                 None,

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -185,9 +185,11 @@ impl Winit {
 
         let init = Box::new(move |pinnacle: &mut Pinnacle| {
             let output = winit.output.clone();
-            output.create_global::<State>(&display_handle);
+            let global = output.create_global::<State>(&display_handle);
 
             pinnacle.output_focus_stack.set_focus(output.clone());
+
+            pinnacle.outputs.insert(output.clone(), Some(global));
 
             pinnacle
                 .shm_state

--- a/src/config.rs
+++ b/src/config.rs
@@ -381,7 +381,7 @@ impl Pinnacle {
         // Clear state
 
         debug!("Clearing tags");
-        for output in self.space.outputs() {
+        for output in self.outputs.keys() {
             output.with_state_mut(|state| state.tags.clear());
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -347,6 +347,7 @@ pub struct ConnectorSavedState {
     pub tags: Vec<Tag>,
     /// The output's previous scale
     pub scale: Option<smithay::output::Scale>,
+    // TODO: transform
 }
 
 /// Parse a metaconfig file in `config_dir`, if any.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -998,6 +998,9 @@ impl OutputManagementHandler for State {
                 }
             }
         }
+        self.pinnacle
+            .output_management_manager_state
+            .update::<State>();
         true
     }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -77,6 +77,7 @@ use crate::{
     delegate_output_power_management, delegate_screencopy,
     focus::{keyboard::KeyboardFocusTarget, pointer::PointerFocusTarget},
     handlers::xdg_shell::snapshot_pre_commit_hook,
+    output::OutputMode,
     protocol::{
         foreign_toplevel::{self, ForeignToplevelHandler, ForeignToplevelManagerState},
         gamma_control::{GammaControlHandler, GammaControlManagerState},
@@ -979,7 +980,7 @@ impl OutputManagementHandler for State {
                     self.pinnacle.change_output_state(
                         &mut self.backend,
                         &output,
-                        mode,
+                        mode.map(OutputMode::Smithay),
                         transform,
                         scale.map(Scale::Fractional),
                         position,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -32,20 +32,24 @@ impl Pinnacle {
         output: &Output,
         geometries: Vec<Rectangle<i32, Logical>>,
     ) -> Vec<(WindowElement, Serial)> {
-        let windows_on_foc_tags = output.with_state(|state| {
+        let (windows_on_foc_tags, to_unmap) = output.with_state(|state| {
             let focused_tags = state.focused_tags().collect::<Vec<_>>();
             self.windows
                 .iter()
-                .filter(|win| !win.is_x11_override_redirect())
-                .filter(|win| {
+                .filter(|win| win.output(self).as_ref() == Some(output))
+                .cloned()
+                .partition::<Vec<_>, _>(|win| {
                     win.with_state(|state| state.tags.iter().any(|tg| focused_tags.contains(&tg)))
                 })
-                .cloned()
-                .collect::<Vec<_>>()
         });
+
+        for win in to_unmap {
+            self.space.unmap_elem(&win);
+        }
 
         let tiled_windows = windows_on_foc_tags
             .iter()
+            .filter(|win| !win.is_x11_override_redirect())
             .filter(|win| {
                 win.with_state(|state| {
                     state.floating_or_tiled.is_tiled() && state.fullscreen_or_maximized.is_neither()

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -158,11 +158,19 @@ impl LayoutState {
 }
 
 impl Pinnacle {
-    pub fn request_layout(&mut self, output: &Output) -> Option<LayoutRequestId> {
+    pub fn request_layout(&mut self, output: &Output) {
+        if self
+            .outputs
+            .get(output)
+            .is_some_and(|global| global.is_none())
+        {
+            return;
+        }
+
         let id = self.layout_state.next_id();
         let Some(sender) = self.layout_state.layout_request_sender.as_ref() else {
             warn!("Layout requested but no client has connected to the layout service");
-            return None;
+            return;
         };
 
         let windows_on_foc_tags = output.with_state(|state| {
@@ -213,8 +221,6 @@ impl Pinnacle {
             output_width: Some(output_width as u32),
             output_height: Some(output_height as u32),
         }));
-
-        Some(id)
     }
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -258,9 +258,15 @@ impl Pinnacle {
         }
         self.unmapped_outputs.remove(output);
 
+        for layer in layer_map_for_output(output).layers() {
+            layer.layer_surface().send_close();
+        }
+
         self.space.unmap_output(output);
 
         self.gamma_control_manager_state.output_removed(output);
+
+        self.output_power_management_state.output_removed(output);
 
         self.output_management_manager_state.remove_head(output);
         self.output_management_manager_state.update::<State>();
@@ -279,9 +285,5 @@ impl Pinnacle {
                 scale: Some(output.current_scale()),
             },
         );
-
-        for layer in layer_map_for_output(output).layers() {
-            layer.layer_surface().send_close();
-        }
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -8,7 +8,7 @@ use pinnacle_api_defs::pinnacle::signal::v0alpha1::{
 use smithay::{
     desktop::layer_map_for_output,
     output::{Mode, Output, Scale},
-    reexports::calloop::LoopHandle,
+    reexports::{calloop::LoopHandle, drm},
     utils::{Logical, Point, Transform},
     wayland::session_lock::LockSurface,
 };
@@ -122,12 +122,27 @@ impl OutputState {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum OutputMode {
+    Smithay(Mode),
+    Drm(drm::control::Mode),
+}
+
+impl From<OutputMode> for Mode {
+    fn from(value: OutputMode) -> Self {
+        match value {
+            OutputMode::Smithay(mode) => mode,
+            OutputMode::Drm(mode) => Mode::from(mode),
+        }
+    }
+}
+
 impl Pinnacle {
     pub fn change_output_state(
         &mut self,
         backend: &mut impl BackendData,
         output: &Output,
-        mode: Option<Mode>,
+        mode: Option<OutputMode>,
         transform: Option<Transform>,
         scale: Option<Scale>,
         location: Option<Point<i32, Logical>>,

--- a/src/output.rs
+++ b/src/output.rs
@@ -207,9 +207,6 @@ impl Pinnacle {
 
             lock_surface.send_configure();
         }
-
-        self.output_management_manager_state
-            .update_head::<State>(output);
     }
 
     pub fn set_output_enabled(&mut self, output: &Output, enabled: bool) {
@@ -266,6 +263,7 @@ impl Pinnacle {
         self.gamma_control_manager_state.output_removed(output);
 
         self.output_management_manager_state.remove_head(output);
+        self.output_management_manager_state.update::<State>();
 
         self.signal_state.output_disconnect.signal(|buffer| {
             buffer.push_back(OutputDisconnectResponse {

--- a/src/output.rs
+++ b/src/output.rs
@@ -219,5 +219,8 @@ impl Pinnacle {
 
             lock_surface.send_configure();
         }
+
+        self.output_management_manager_state
+            .update_head::<State>(output);
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,3 +1,4 @@
 pub mod foreign_toplevel;
 pub mod gamma_control;
+pub mod output_management;
 pub mod screencopy;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,4 +1,6 @@
 pub mod foreign_toplevel;
 pub mod gamma_control;
 pub mod output_management;
+pub mod output_power_management;
 pub mod screencopy;
+

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,4 +3,3 @@ pub mod gamma_control;
 pub mod output_management;
 pub mod output_power_management;
 pub mod screencopy;
-

--- a/src/protocol/gamma_control.rs
+++ b/src/protocol/gamma_control.rs
@@ -150,7 +150,6 @@ pub trait GammaControlHandler {
     fn gamma_control_destroyed(&mut self, output: &Output);
 }
 
-#[allow(missing_docs)]
 #[macro_export]
 macro_rules! delegate_gamma_control {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {

--- a/src/protocol/output_management.rs
+++ b/src/protocol/output_management.rs
@@ -101,7 +101,7 @@ pub struct OutputData {
     position: Point<i32, Logical>,
     transform: Transform,
     scale: f64,
-    adaptive_sync: bool,
+    _adaptive_sync: bool,
 }
 
 impl OutputManagementManagerState {
@@ -127,7 +127,7 @@ impl OutputManagementManagerState {
             position: output.current_location(),
             transform: output.current_transform(),
             scale: output.current_scale().fractional_scale(),
-            adaptive_sync: false, // TODO:
+            _adaptive_sync: false, // TODO:
         };
 
         self.outputs.insert(output.clone(), output_data);
@@ -336,7 +336,7 @@ where
     head.physical_size(physical_props.size.w, physical_props.size.h);
 
     let mut wlr_modes = Vec::new();
-    for mode in output.modes() {
+    for mode in output.with_state(|state| state.modes.clone()) {
         let wlr_mode = client
             .create_resource::<ZwlrOutputModeV1, _, D>(display, manager.version(), mode)
             .unwrap();
@@ -551,13 +551,13 @@ where
 
 impl<D> Dispatch<ZwlrOutputHeadV1, Output, D> for OutputManagementManagerState {
     fn request(
-        state: &mut D,
-        client: &Client,
-        resource: &ZwlrOutputHeadV1,
+        _state: &mut D,
+        _client: &Client,
+        _resource: &ZwlrOutputHeadV1,
         request: <ZwlrOutputHeadV1 as Resource>::Request,
-        data: &Output,
-        dhandle: &DisplayHandle,
-        data_init: &mut DataInit<'_, D>,
+        _data: &Output,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
     ) {
         match request {
             zwlr_output_head_v1::Request::Release => {
@@ -570,13 +570,13 @@ impl<D> Dispatch<ZwlrOutputHeadV1, Output, D> for OutputManagementManagerState {
 
 impl<D> Dispatch<ZwlrOutputModeV1, Mode, D> for OutputManagementManagerState {
     fn request(
-        state: &mut D,
-        client: &Client,
-        resource: &ZwlrOutputModeV1,
+        _state: &mut D,
+        _client: &Client,
+        _resource: &ZwlrOutputModeV1,
         request: <ZwlrOutputModeV1 as Resource>::Request,
-        data: &Mode,
-        dhandle: &DisplayHandle,
-        data_init: &mut DataInit<'_, D>,
+        _data: &Mode,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
     ) {
         match request {
             zwlr_output_mode_v1::Request::Release => {

--- a/src/protocol/output_management.rs
+++ b/src/protocol/output_management.rs
@@ -590,8 +590,6 @@ where
                 let correct_serial = manager_data.serial == serial;
 
                 if !correct_serial {
-                    tracing::info!(mgr_serial = manager_data.serial, cfg_serial = serial);
-                    tracing::info!("cancelled, incorrect serial 527");
                     config.cancelled();
                     config
                         .data::<PendingOutputConfiguration>()
@@ -736,7 +734,6 @@ where
                     manager_for_configuration(state, resource).map(|(_, data)| data.serial);
 
                 if manager_serial != Some(pending_data.serial) {
-                    tracing::info!("cancelled, incorrect serial 661");
                     resource.cancelled();
                     data.cancelled = true;
                     return;
@@ -765,7 +762,6 @@ where
                     manager_for_configuration(state, resource).map(|(_, data)| data.serial);
 
                 if manager_serial != Some(pending_data.serial) {
-                    tracing::info!("cancelled, incorrect serial 689");
                     resource.cancelled();
                     data.cancelled = true;
                     return;
@@ -795,7 +791,6 @@ where
                     manager_for_configuration(state, resource).map(|(_, data)| data.serial);
 
                 if manager_serial != Some(pending_data.serial) {
-                    tracing::info!("cancelled, incorrect serial 718");
                     resource.cancelled();
                     data.cancelled = true;
                     return;

--- a/src/protocol/output_power_management.rs
+++ b/src/protocol/output_power_management.rs
@@ -1,0 +1,206 @@
+use std::collections::HashMap;
+
+use smithay::{
+    output::Output,
+    reexports::{
+        wayland_protocols_wlr::output_power_management::v1::server::{
+            zwlr_output_power_manager_v1::{self, ZwlrOutputPowerManagerV1},
+            zwlr_output_power_v1::{self, ZwlrOutputPowerV1},
+        },
+        wayland_server::{
+            self, backend::ClientId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch,
+            Resource, WEnum,
+        },
+    },
+};
+use tracing::warn;
+
+use crate::state::WithState;
+
+const VERSION: u32 = 1;
+
+pub struct OutputPowerManagementState {
+    clients: HashMap<Output, ZwlrOutputPowerV1>,
+}
+
+pub struct OutputPowerManagementGlobalData {
+    filter: Box<dyn Fn(&Client) -> bool + Send + Sync + 'static>,
+}
+
+pub trait OutputPowerManagementHandler {
+    fn output_power_management_state(&mut self) -> &mut OutputPowerManagementState;
+    fn set_mode(&mut self, output: &Output, powered: bool);
+}
+
+impl OutputPowerManagementState {
+    pub fn new<D, F>(display: &DisplayHandle, filter: F) -> Self
+    where
+        D: GlobalDispatch<ZwlrOutputPowerManagerV1, OutputPowerManagementGlobalData> + 'static,
+        F: Fn(&Client) -> bool + Send + Sync + 'static,
+    {
+        let data = OutputPowerManagementGlobalData {
+            filter: Box::new(filter),
+        };
+
+        display.create_global::<D, ZwlrOutputPowerManagerV1, _>(VERSION, data);
+
+        Self {
+            clients: HashMap::new(),
+        }
+    }
+
+    pub fn output_removed(&mut self, output: &Output) {
+        if let Some(power) = self.clients.remove(output) {
+            power.failed();
+        }
+    }
+}
+
+impl<D> GlobalDispatch<ZwlrOutputPowerManagerV1, OutputPowerManagementGlobalData, D>
+    for OutputPowerManagementState
+where
+    D: Dispatch<ZwlrOutputPowerManagerV1, ()> + OutputPowerManagementHandler,
+{
+    fn bind(
+        _state: &mut D,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: wayland_server::New<ZwlrOutputPowerManagerV1>,
+        _global_data: &OutputPowerManagementGlobalData,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(resource, ());
+    }
+
+    fn can_view(client: Client, global_data: &OutputPowerManagementGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+impl<D> Dispatch<ZwlrOutputPowerManagerV1, (), D> for OutputPowerManagementState
+where
+    D: Dispatch<ZwlrOutputPowerV1, ()> + OutputPowerManagementHandler,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        _resource: &ZwlrOutputPowerManagerV1,
+        request: <ZwlrOutputPowerManagerV1 as wayland_server::Resource>::Request,
+        _data: &(),
+        _dhandle: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            zwlr_output_power_manager_v1::Request::GetOutputPower { id, output } => {
+                let Some(output) = Output::from_resource(&output) else {
+                    warn!("wlr-output-power-management: no output for wl_output {output:?}");
+                    let power = data_init.init(id, ());
+                    power.failed();
+                    return;
+                };
+
+                if state
+                    .output_power_management_state()
+                    .clients
+                    .contains_key(&output)
+                {
+                    warn!(
+                        "wlr-output-power-management: {} already has an active power manager",
+                        output.name()
+                    );
+                    let power = data_init.init(id, ());
+                    power.failed();
+                    return;
+                }
+
+                let power = data_init.init(id, ());
+                let is_powered = output.with_state(|state| state.powered);
+                power.mode(match is_powered {
+                    true => zwlr_output_power_v1::Mode::On,
+                    false => zwlr_output_power_v1::Mode::Off,
+                });
+
+                state
+                    .output_power_management_state()
+                    .clients
+                    .insert(output, power);
+            }
+            zwlr_output_power_manager_v1::Request::Destroy => (),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<ZwlrOutputPowerV1, (), D> for OutputPowerManagementState
+where
+    D: Dispatch<ZwlrOutputPowerV1, ()> + OutputPowerManagementHandler,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        resource: &ZwlrOutputPowerV1,
+        request: <ZwlrOutputPowerV1 as wayland_server::Resource>::Request,
+        _data: &(),
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            zwlr_output_power_v1::Request::SetMode { mode } => {
+                let Some(output) = state
+                    .output_power_management_state()
+                    .clients
+                    .iter()
+                    .find_map(|(output, power)| (power == resource).then_some(output.clone()))
+                else {
+                    return;
+                };
+
+                state.set_mode(
+                    &output,
+                    match mode {
+                        WEnum::Value(zwlr_output_power_v1::Mode::On) => true,
+                        WEnum::Value(zwlr_output_power_v1::Mode::Off) => false,
+                        mode => {
+                            resource.post_error(
+                                zwlr_output_power_v1::Error::InvalidMode,
+                                format!("invalid mode {mode:?}"),
+                            );
+                            return;
+                        }
+                    },
+                );
+            }
+            zwlr_output_power_v1::Request::Destroy => {
+                state
+                    .output_power_management_state()
+                    .clients
+                    .retain(|_, power| power == resource);
+            }
+            _ => todo!(),
+        }
+    }
+
+    fn destroyed(state: &mut D, _client: ClientId, resource: &ZwlrOutputPowerV1, _data: &()) {
+        state
+            .output_power_management_state()
+            .clients
+            .retain(|_, power| power == resource);
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_output_power_management {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::output_power_management::v1::server::zwlr_output_power_manager_v1::ZwlrOutputPowerManagerV1: $crate::protocol::output_power_management::OutputPowerManagementGlobalData
+        ] => $crate::protocol::output_power_management::OutputPowerManagementState);
+
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::output_power_management::v1::server::zwlr_output_power_manager_v1::ZwlrOutputPowerManagerV1: ()
+        ] => $crate::protocol::output_power_management::OutputPowerManagementState);
+
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::output_power_management::v1::server::zwlr_output_power_v1::ZwlrOutputPowerV1: ()
+        ] => $crate::protocol::output_power_management::OutputPowerManagementState);
+    };
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -153,8 +153,7 @@ pub struct Pinnacle {
     /// WlSurfaces with an attached idle inhibitor.
     pub idle_inhibiting_surfaces: HashSet<WlSurface>,
 
-    pub outputs: HashMap<Output, GlobalId>,
-    pub unmapped_outputs: HashSet<Output>,
+    pub outputs: HashMap<Output, Option<GlobalId>>,
 }
 
 impl State {
@@ -355,7 +354,6 @@ impl Pinnacle {
             idle_inhibiting_surfaces: HashSet::new(),
 
             outputs: HashMap::new(),
-            unmapped_outputs: HashSet::new(),
         };
 
         Ok(pinnacle)

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,6 +13,7 @@ use crate::{
         foreign_toplevel::{self, ForeignToplevelManagerState},
         gamma_control::GammaControlManagerState,
         output_management::OutputManagementManagerState,
+        output_power_management::OutputPowerManagementState,
         screencopy::ScreencopyManagerState,
     },
     window::WindowElement,
@@ -109,6 +110,7 @@ pub struct Pinnacle {
     pub xwayland_shell_state: XWaylandShellState,
     pub idle_notifier_state: IdleNotifierState<State>,
     pub output_management_manager_state: OutputManagementManagerState,
+    pub output_power_management_state: OutputPowerManagementState,
 
     pub lock_state: LockState,
 
@@ -306,6 +308,10 @@ impl Pinnacle {
             xwayland_shell_state: XWaylandShellState::new::<State>(&display_handle),
             idle_notifier_state: IdleNotifierState::new(&display_handle, loop_handle),
             output_management_manager_state: OutputManagementManagerState::new::<State, _>(
+                &display_handle,
+                filter_restricted_client,
+            ),
+            output_power_management_state: OutputPowerManagementState::new::<State, _>(
                 &display_handle,
                 filter_restricted_client,
             ),

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,6 +19,7 @@ use crate::{
     window::WindowElement,
 };
 use anyhow::Context;
+use indexmap::IndexMap;
 use pinnacle_api_defs::pinnacle::v0alpha1::ShutdownWatchResponse;
 use smithay::{
     desktop::{PopupManager, Space},
@@ -153,7 +154,7 @@ pub struct Pinnacle {
     /// WlSurfaces with an attached idle inhibitor.
     pub idle_inhibiting_surfaces: HashSet<WlSurface>,
 
-    pub outputs: HashMap<Output, Option<GlobalId>>,
+    pub outputs: IndexMap<Output, Option<GlobalId>>,
 }
 
 impl State {
@@ -353,7 +354,7 @@ impl Pinnacle {
 
             idle_inhibiting_surfaces: HashSet::new(),
 
-            outputs: HashMap::new(),
+            outputs: IndexMap::new(),
         };
 
         Ok(pinnacle)

--- a/src/state.rs
+++ b/src/state.rs
@@ -22,10 +22,11 @@ use pinnacle_api_defs::pinnacle::v0alpha1::ShutdownWatchResponse;
 use smithay::{
     desktop::{PopupManager, Space},
     input::{keyboard::XkbConfig, pointer::CursorImageStatus, Seat, SeatState},
+    output::Output,
     reexports::{
         calloop::{generic::Generic, Interest, LoopHandle, LoopSignal, Mode, PostAction},
         wayland_server::{
-            backend::{ClientData, ClientId, DisconnectReason},
+            backend::{ClientData, ClientId, DisconnectReason, GlobalId},
             protocol::wl_surface::WlSurface,
             Client, Display, DisplayHandle,
         },
@@ -149,6 +150,9 @@ pub struct Pinnacle {
 
     /// WlSurfaces with an attached idle inhibitor.
     pub idle_inhibiting_surfaces: HashSet<WlSurface>,
+
+    pub outputs: HashMap<Output, GlobalId>,
+    pub unmapped_outputs: HashSet<Output>,
 }
 
 impl State {
@@ -343,6 +347,9 @@ impl Pinnacle {
             root_surface_cache: HashMap::new(),
 
             idle_inhibiting_surfaces: HashSet::new(),
+
+            outputs: HashMap::new(),
+            unmapped_outputs: HashSet::new(),
         };
 
         Ok(pinnacle)

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -26,8 +26,8 @@ impl TagId {
     /// Get the tag associated with this id.
     pub fn tag(&self, pinnacle: &Pinnacle) -> Option<Tag> {
         pinnacle
-            .space
-            .outputs()
+            .outputs
+            .keys()
             .flat_map(|op| op.with_state(|state| state.tags.clone()))
             .find(|tag| &tag.id() == self)
     }
@@ -118,8 +118,8 @@ impl Tag {
     /// RefCell Safety: This uses RefCells on every mapped output.
     pub fn output(&self, pinnacle: &Pinnacle) -> Option<Output> {
         pinnacle
-            .space
-            .outputs()
+            .outputs
+            .keys()
             .find(|output| output.with_state(|state| state.tags.iter().any(|tg| tg == self)))
             .cloned()
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -308,7 +308,7 @@ impl Pinnacle {
 
         self.z_index_stack.retain(|win| win != window);
 
-        for output in self.space.outputs() {
+        for output in self.outputs.keys() {
             output.with_state_mut(|state| state.focus_stack.stack.retain(|win| win != window));
         }
     }


### PR DESCRIPTION
TODO:
- [x] wlr-output-management
- [x] wlr-output-power-management
- [x] Custom modes and modelines
- [x] See how API calls on disabled outputs works
- [x] Move to `Pinnacle.outputs` as the single source of truth for outputs instead of the space
- [x] Finish all the TODOs and deal with all the unwraps
- [x] Fail output management applications when setting a mode no worky
- [x] Fail output management applications when reusing a configuration
- [x] Add `enabled` and `powered` fields to API output properties
- ~~Move to libdisplay-info for EDID parsing~~
    - Splitting off of this PR