### PR TITLE
Preliminary snowcap integration (Rust)

### DIFF
--- a/.github/workflows/ci.pinnacle.yml
+++ b/.github/workflows/ci.pinnacle.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Get Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache stuff
@@ -39,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Get Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache stuff
@@ -65,6 +69,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Get Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -77,6 +83,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Get Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.pinnacle.yml
+++ b/.github/workflows/ci.pinnacle.yml
@@ -55,10 +55,10 @@ jobs:
         uses: extractions/setup-just@v1
       - name: Test
         if: ${{ runner.debug != '1' }}
-        run: just install test -- --test-threads=1
+        run: just install test --no-default-features -- --test-threads=1
       - name: Test (debug)
         if: ${{ runner.debug == '1' }}
-        run: RUST_LOG=debug RUST_BACKTRACE=1 just install test -- --nocapture --test-threads=1
+        run: RUST_LOG=debug RUST_BACKTRACE=1 just install test --no-default-features -- --nocapture --test-threads=1
   check-format:
     runs-on: ubuntu-24.04
     name: Check formatting

--- a/.github/workflows/ldoc.yml
+++ b/.github/workflows/ldoc.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Get ldoc_gen
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get protoc
         run: sudo apt install protobuf-compiler
       - name: Build docs
-        run: cd ./api/rust && cargo doc --no-deps -p pinnacle-api -p tokio -p xkbcommon
+        run: cd ./api/rust && cargo doc --no-deps -p pinnacle-api -p tokio -p xkbcommon -p snowcap-api
       - name: Create index.html
         run: echo "<meta http-equiv=\"refresh\" content=\"0; url=pinnacle_api\">" > ./target/doc/index.html
       - name: Deploy

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Get protoc
         run: sudo apt install protobuf-compiler
       - name: Build docs

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "snowcap"]
+	path = snowcap
+	url = https://github.com/pinnacle-comp/snowcap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,26 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
+name = "ab_glyph"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "2e53b0a3d5760cd2ba9b787ae0c6440ad18ee294ff71b05e3381c900a7d16cfd"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
+
+[[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -38,6 +54,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-activity"
@@ -113,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -132,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 dependencies = [
  "backtrace",
 ]
@@ -153,6 +175,27 @@ checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -188,7 +231,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -199,7 +242,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -261,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -281,6 +324,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +349,12 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-sys"
@@ -308,7 +372,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
 dependencies = [
  "block-sys",
- "objc2",
+ "objc2 0.4.1",
+]
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -318,7 +391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "regex-automata 0.4.6",
+ "regex-automata 0.4.7",
  "serde",
 ]
 
@@ -327,6 +400,12 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -339,13 +418,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
+checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -401,10 +480,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.1.6"
+name = "calloop-wayland-source"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "camino"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 dependencies = [
  "serde",
 ]
@@ -434,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 dependencies = [
  "jobserver",
  "libc",
@@ -462,12 +553,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "cgmath"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a98d30140e3296250832bbaaff83b27dcd6fa3cc70fb6f1f3e5c9c0023b5317"
 dependencies = [
- "approx",
+ "approx 0.4.0",
  "num-traits",
 ]
 
@@ -487,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -497,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -509,21 +606,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "cliclack"
@@ -539,10 +636,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "clipboard_macos"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145a7f9e9b89453bc0a5e32d166456405d389cea5b578f57f1274b1397588a95"
+dependencies = [
+ "objc",
+ "objc-foundation",
+ "objc_id",
+]
+
+[[package]]
+name = "clipboard_wayland"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003f886bc4e2987729d10c1db3424e7f80809f3fc22dbc16c685738887cb37b8"
+dependencies = [
+ "smithay-clipboard",
+]
+
+[[package]]
+name = "clipboard_x11"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4274ea815e013e0f9f04a2633423e14194e408a0576c943ce3d14ca56c50031c"
+dependencies = [
+ "thiserror",
+ "x11rb",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "com"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
+dependencies = [
+ "com_macros",
+]
+
+[[package]]
+name = "com_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
+dependencies = [
+ "com_macros_support",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "com_macros_support"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "combine"
@@ -646,6 +823,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmic-text"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75acbfb314aeb4f5210d379af45ed1ec2c98c7f1790bf57b8a4c562ac0c51b71"
+dependencies = [
+ "fontdb",
+ "libm",
+ "log",
+ "rangemap",
+ "rustc-hash",
+ "rustybuzz",
+ "self_cell",
+ "swash",
+ "sys-locale",
+ "unicode-bidi",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -697,15 +904,38 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "ctor-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f791803201ab277ace03903de1594460708d2d54df6053f2d9e82f592b19e3b"
 
 [[package]]
 name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
+
+[[package]]
+name = "d3d12"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
+dependencies = [
+ "bitflags 2.5.0",
+ "libloading 0.8.3",
+ "winapi",
+]
 
 [[package]]
 name = "deranged"
@@ -816,9 +1046,9 @@ checksum = "2ab5fa33485cd85ac354df485819a63360fefa312fe04cffe65e6f175be1522c"
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "encode_unicode"
@@ -843,19 +1073,59 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
+name = "error-code"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+
+[[package]]
+name = "etagere"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff377452246a4a2e0ef3a7e85ce78ed77c7f93c3a4771e1c93d0cc0c69eb411"
+dependencies = [
+ "euclid",
+ "svg_fmt",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f0eb73b934648cd7a4a61f1b15391cd95dab0b4da6e2e66c2a072c144b4a20"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -875,10 +1145,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "font-types"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fd7136aca682873d859ef34494ab1a7d3f57ecd485ed40eb6437ee8c85aa29"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020e203f177c0fb250fb19455a252e838d2bbbce1f80f25ecc42402aafa8cd38"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2 0.8.0",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.19.2",
+]
 
 [[package]]
 name = "foreign-types"
@@ -898,7 +1210,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -947,6 +1259,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -963,7 +1276,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1053,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "gl_generator"
@@ -1066,6 +1379,107 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glow"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "glyphon"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a62d0338e4056db6a73221c2fb2e30619452f6ea9651bac4110f51b0f7a7581"
+dependencies = [
+ "cosmic-text",
+ "etagere",
+ "lru",
+ "wgpu",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+dependencies = [
+ "bitflags 2.5.0",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror",
+ "winapi",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+dependencies = [
+ "bitflags 2.5.0",
+ "gpu-descriptor-types",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
+name = "guillotiere"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782"
+dependencies = [
+ "euclid",
+ "svg_fmt",
 ]
 
 [[package]]
@@ -1088,6 +1502,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1522,25 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hassle-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
+dependencies = [
+ "bitflags 2.5.0",
+ "com",
+ "libc",
+ "libloading 0.8.3",
+ "thiserror",
+ "widestring",
+ "winapi",
+]
 
 [[package]]
 name = "heck"
@@ -1110,6 +1553,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "http"
@@ -1135,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
 
 [[package]]
 name = "httpdate"
@@ -1147,9 +1596,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1205,14 +1654,184 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4eb0fbbefb8c428b70680e77ed9013887b17c1d6be366b40f264f956d1a096"
+dependencies = [
+ "iced_core",
+ "iced_futures",
+ "iced_renderer",
+ "iced_widget",
+ "iced_winit",
+ "thiserror",
+]
+
+[[package]]
+name = "iced_core"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d7e6bbd197f311ed3d8b71651876b0ce01318fde52cda862a9a7a4373c9b930"
+dependencies = [
+ "bitflags 2.5.0",
+ "glam",
+ "log",
+ "num-traits",
+ "palette",
+ "raw-window-handle",
+ "smol_str",
+ "thiserror",
+ "web-time",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "iced_futures"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370bad88fb3832cbeeb3fa6c486b4701fb7e8da32a753b3101d4ce81fc1d9497"
+dependencies = [
+ "futures",
+ "iced_core",
+ "log",
+ "tokio",
+ "wasm-bindgen-futures",
+ "wasm-timer",
+]
+
+[[package]]
+name = "iced_graphics"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a044c193ef0840eacabfa05424717331d1fc5b3ecb9a89316200c75da2ba9a4"
+dependencies = [
+ "bitflags 2.5.0",
+ "bytemuck",
+ "cosmic-text",
+ "half",
+ "iced_core",
+ "iced_futures",
+ "log",
+ "once_cell",
+ "raw-window-handle",
+ "rustc-hash",
+ "thiserror",
+ "unicode-segmentation",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "iced_renderer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c281e03001d566058f53dec9325bbe61c62da715341206d2627f57a3ecc7f69"
+dependencies = [
+ "iced_graphics",
+ "iced_tiny_skia",
+ "iced_wgpu",
+ "log",
+ "thiserror",
+]
+
+[[package]]
+name = "iced_runtime"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79f852c01cc6d61663c94379cb3974ac3ad315a28c504e847d573e094f46822"
+dependencies = [
+ "iced_core",
+ "iced_futures",
+ "raw-window-handle",
+ "thiserror",
+]
+
+[[package]]
+name = "iced_style"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ea42a740915d2a5a9ff9c3aa0bca28b16e9fb660bc8f675eed71d186cadb579"
+dependencies = [
+ "iced_core",
+ "once_cell",
+ "palette",
+]
+
+[[package]]
+name = "iced_tiny_skia"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2228781f4d381a1cbbd7905a9f077351aa8d37269094021d5d9e779f130aff"
+dependencies = [
+ "bytemuck",
+ "cosmic-text",
+ "iced_graphics",
+ "kurbo",
+ "log",
+ "rustc-hash",
+ "softbuffer",
+ "tiny-skia",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "iced_wgpu"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c243b6700452886aac1ee1987e84d9fb43b56b53fea9a1eb67713fd0fde244"
+dependencies = [
+ "bitflags 2.5.0",
+ "bytemuck",
+ "futures",
+ "glam",
+ "glyphon",
+ "guillotiere",
+ "iced_graphics",
+ "log",
+ "once_cell",
+ "wgpu",
+]
+
+[[package]]
+name = "iced_widget"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e01b2212adecf1cb80e2267f302c0e0c263e55f97812056949199ccf9f0b908"
+dependencies = [
+ "iced_renderer",
+ "iced_runtime",
+ "iced_style",
+ "num-traits",
+ "thiserror",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "iced_winit"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63f66831d0e399b93f631739121a6171780d344b275d56808b9504d8ca75c7d2"
+dependencies = [
+ "iced_graphics",
+ "iced_runtime",
+ "iced_style",
+ "log",
+ "thiserror",
+ "tracing",
+ "web-sys",
+ "winapi",
+ "window_clipboard",
+ "winit",
+]
+
+[[package]]
 name = "icrate"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
 dependencies = [
- "block2",
+ "block2 0.3.0",
  "dispatch",
- "objc2",
+ "objc2 0.4.1",
 ]
 
 [[package]]
@@ -1280,9 +1899,9 @@ checksum = "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0"
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -1376,10 +1995,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading 0.8.3",
+ "pkg-config",
+]
+
+[[package]]
 name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kurbo"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1618d4ebd923e97d67e7cd363d80aef35fe961005cbbbb3d2dad8bdd1bc63440"
+dependencies = [
+ "arrayvec",
+ "smallvec",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1389,9 +2029,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libdisplay-info-sys"
@@ -1415,8 +2055,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
@@ -1471,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1496,6 +2142,24 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -1555,6 +2219,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+dependencies = [
+ "bitflags 2.5.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,11 +2241,12 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1585,6 +2265,26 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "naga"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
+dependencies = [
+ "bit-set",
+ "bitflags 2.5.0",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap 2.2.6",
+ "log",
+ "num-traits",
+ "rustc-hash",
+ "spirv",
+ "termcolor",
+ "thiserror",
+ "unicode-xid",
+]
 
 [[package]]
 name = "ndk"
@@ -1689,7 +2389,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1708,10 +2408,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "objc-sys"
-version = "0.3.3"
+name = "objc"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da284c198fb9b7b0603f8635185e85fbd5b64ee154b1ed406d489077de2d6d60"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
@@ -1720,7 +2441,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
 dependencies = [
  "objc-sys",
- "objc2-encode",
+ "objc2-encode 3.0.0",
+]
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode 4.0.3",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -1730,10 +2501,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
-name = "object"
-version = "0.32.2"
+name = "objc2-encode"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2 0.5.1",
+ "dispatch",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
+]
+
+[[package]]
+name = "object"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "memchr",
 ]
@@ -1775,13 +2608,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.2"
+name = "owned_ttf_parser"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "6b41438d2fc63c46c74a2203bf5ccd82c41ba04347b2fcf5754f230b167067d5"
+dependencies = [
+ "ttf-parser 0.21.1",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx 0.5.1",
+ "fast-srgb8",
+ "palette_derive",
+ "phf",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1798,6 +2689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,12 +2702,54 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.2.6",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1830,7 +2769,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1869,6 +2808,8 @@ dependencies = [
  "shellexpand",
  "smithay",
  "smithay-drm-extras",
+ "snowcap",
+ "snowcap-api",
  "sysinfo",
  "temp-env",
  "tempfile",
@@ -1899,6 +2840,7 @@ dependencies = [
  "pinnacle-api-defs",
  "pinnacle-api-macros",
  "rand",
+ "snowcap-api",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -1922,7 +2864,7 @@ version = "0.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1932,10 +2874,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "polling"
-version = "3.7.0"
+name = "png"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6a007746f34ed64099e88783b0ae369eaa3da6392868ba262e2af9b8fbaea1"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -1965,13 +2920,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1985,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -2008,14 +2969,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "prost"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2023,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck",
@@ -2038,28 +2999,28 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.66",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost",
 ]
@@ -2113,10 +3074,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-window-handle"
-version = "0.6.1"
+name = "range-alloc"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc3bcbdb1ddfc11e700e62968e6b4cc9c75bb466464ad28fb61c5b2c964418b"
+checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
+
+[[package]]
+name = "rangemap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rayon"
@@ -2136,6 +3109,25 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b8af39d1f23869711ad4cea5e7835a20daa987f80232f7f2a2374d648ca64d"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2178,14 +3170,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2199,13 +3191,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2216,15 +3208,33 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "roxmltree"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -2244,15 +3254,32 @@ dependencies = [
  "bitflags 2.5.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
+name = "rustybuzz"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee8fe2a8461a0854a37101fe7a1b13998d0cfa987e43248e81d2a5f4570f6fa"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytemuck",
+ "libm",
+ "smallvec",
+ "ttf-parser 0.20.0",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -2288,6 +3315,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sctk-adwaita"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2 0.9.4",
+ "smithay-client-toolkit 0.18.1",
+ "tiny-skia",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,22 +3344,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2366,12 +3412,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -2426,9 +3493,9 @@ dependencies = [
  "udev",
  "wayland-backend",
  "wayland-egl",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-protocols-misc",
- "wayland-protocols-wlr",
+ "wayland-protocols-wlr 0.2.0",
  "wayland-server",
  "wayland-sys",
  "winit",
@@ -2444,7 +3511,7 @@ checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
 dependencies = [
  "bitflags 2.5.0",
  "calloop 0.12.4",
- "calloop-wayland-source",
+ "calloop-wayland-source 0.2.0",
  "cursor-icon",
  "libc",
  "log",
@@ -2455,10 +3522,49 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
+ "wayland-protocols 0.31.2",
+ "wayland-protocols-wlr 0.2.0",
  "wayland-scanner",
  "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "837d3067369e24aeda699a5d9fc5aa14ca14a84dd70aeed7156bfa04a5605b32"
+dependencies = [
+ "bitflags 2.5.0",
+ "bytemuck",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2 0.9.4",
+ "pkg-config",
+ "rustix",
+ "thiserror",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols 0.32.1",
+ "wayland-protocols-wlr 0.3.1",
+ "wayland-scanner",
+ "xkbcommon",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c091e7354ea8059d6ad99eace06dd13ddeedbb0ac72d40a9a6e7ff790525882d"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit 0.18.1",
+ "wayland-backend",
 ]
 
 [[package]]
@@ -2472,11 +3578,63 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "snowcap"
+version = "0.0.1"
+source = "git+https://github.com/pinnacle-comp/snowcap?rev=acb0e29#acb0e29b3da3cdc9a701a6e3819afe56cce58e34"
+dependencies = [
+ "anyhow",
+ "futures",
+ "iced",
+ "iced_futures",
+ "iced_runtime",
+ "iced_wgpu",
+ "prost",
+ "raw-window-handle",
+ "smithay-client-toolkit 0.19.1",
+ "smithay-clipboard",
+ "snowcap-api-defs",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-reflection",
+ "tracing",
+ "tracing-subscriber",
+ "xdg",
+ "xkbcommon",
+]
+
+[[package]]
+name = "snowcap-api"
+version = "0.1.0"
+source = "git+https://github.com/pinnacle-comp/snowcap?rev=acb0e29#acb0e29b3da3cdc9a701a6e3819afe56cce58e34"
+dependencies = [
+ "futures",
+ "snowcap-api-defs",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tower",
+ "xdg",
+ "xkbcommon",
+]
+
+[[package]]
+name = "snowcap-api-defs"
+version = "0.1.0"
+source = "git+https://github.com/pinnacle-comp/snowcap?rev=acb0e29#acb0e29b3da3cdc9a701a6e3819afe56cce58e34"
+dependencies = [
+ "prost",
+ "tonic",
+ "tonic-build",
+ "walkdir",
 ]
 
 [[package]]
@@ -2490,16 +3648,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "softbuffer"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae0d2e93c874cca74fe830bccbd1132299318932d273d2a3c77ad77476a3d7e"
+dependencies = [
+ "as-raw-xcb-connection",
+ "bytemuck",
+ "cfg_aliases 0.2.1",
+ "core-graphics",
+ "drm",
+ "fastrand",
+ "foreign-types",
+ "js-sys",
+ "log",
+ "memmap2 0.9.4",
+ "objc2 0.5.2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "raw-window-handle",
+ "redox_syscall 0.5.1",
+ "rustix",
+ "tiny-xlib",
+ "wasm-bindgen",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-sys",
+ "web-sys",
+ "windows-sys 0.52.0",
+ "x11rb",
+]
+
+[[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "syn"
-version = "2.0.61"
+name = "svg_fmt"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+checksum = "20e16a0f46cf5fd675563ef54f26e83e20f2366bcf027bcb3cc3ed2b98aaf2ca"
+
+[[package]]
+name = "swash"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "682a612b50baf09e8a039547ecf49e6c155690dcb751b1bcb19c93cdeb3d42d4"
+dependencies = [
+ "read-fonts",
+ "yazi",
+ "zeno",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2511,6 +3751,15 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sys-locale"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e801cf239ecd6ccd71f03d270d67dd53d13e90aab208bf4b8fe4ad957ea949b0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "sysinfo"
@@ -2533,7 +3782,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
@@ -2546,6 +3795,15 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2566,7 +3824,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2582,22 +3840,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2644,10 +3902,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.37.0"
+name = "tiny-skia"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tiny-xlib"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d52f22673960ad13af14ff4025997312def1223bfa7c8e4949d099e6b3d5d1c"
+dependencies = [
+ "as-raw-xcb-connection",
+ "ctor-lite",
+ "libloading 0.8.3",
+ "pkg-config",
+ "tracing",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2673,13 +3985,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2708,14 +4020,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.13",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
@@ -2740,15 +4052,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.8",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -2788,7 +4100,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2868,7 +4180,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2917,6 +4229,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
+
+[[package]]
+name = "ttf-parser"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
 name = "udev"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2927,6 +4257,24 @@ dependencies = [
  "libudev-sys",
  "pkg-config",
 ]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
 
 [[package]]
 name = "unicode-ident"
@@ -2941,6 +4289,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d71f5726e5f285a935e9fe8edfd53f0491eb6e9a5774097fdabee7cd8c9cd"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,9 +4308,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -2960,9 +4320,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -3038,7 +4398,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -3072,7 +4432,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3084,10 +4444,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
-name = "wayland-backend"
-version = "0.3.3"
+name = "wasm-timer"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e9e6b6d4a2bb4e7e69433e0b35c7923b95d4dc8503a84d25ec917a4bbfdf07"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -3099,9 +4474,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f"
+checksum = "1e63801c85358a431f986cffa74ba9599ff571fc5774ac113ed3b490c19a1133"
 dependencies = [
  "bitflags 2.5.0",
  "rustix",
@@ -3122,9 +4497,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ce5fa868dd13d11a0d04c5e2e65726d0897be8de247c0c5a65886e283231ba"
+checksum = "a206e8b2b53b1d3fcb9428fec72bc278ce539e2fa81fe2bfc1ab27703d5187b9"
 dependencies = [
  "rustix",
  "wayland-client",
@@ -3133,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-egl"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f652e5a24ae02d2ad536c8fc2d3dcc6c2bd635027cd6103a193e7d75eeda2"
+checksum = "18cede1c33845ccd8fcebf7f107595170abf0ad0a28d47c50b444e06019b16e8"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -3155,6 +4530,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-protocols"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d0f1056570486e26a3773ec633885124d79ae03827de05ba6c85f79904026c"
+dependencies = [
+ "bitflags 2.5.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-protocols-misc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,7 +4549,7 @@ checksum = "bfa5933740b200188c9b4c38601b8212e8c154d7de0d2cb171944e137a77de1e"
 dependencies = [
  "bitflags 2.5.0",
  "wayland-backend",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-scanner",
  "wayland-server",
 ]
@@ -3176,7 +4563,7 @@ dependencies = [
  "bitflags 2.5.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-scanner",
 ]
 
@@ -3189,16 +4576,29 @@ dependencies = [
  "bitflags 2.5.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-scanner",
  "wayland-server",
 ]
 
 [[package]]
-name = "wayland-scanner"
-version = "0.31.1"
+name = "wayland-protocols-wlr"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283"
+checksum = "a7dab47671043d9f5397035975fe1cac639e5bca5cc0b3c32d09f01612e34d24"
+dependencies = [
+ "bitflags 2.5.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.1",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67da50b9f80159dec0ea4c11c13e24ef9e7574bd6ce24b01860a175010cea565"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -3207,9 +4607,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e6e4d5c285bc24ba4ed2d5a4bd4febd5fd904451f465973225c8e99772fdb7"
+checksum = "63e89118bd072ba6ce0f9c2c92fa41f72d1d78a138d2abc497a80a8264565559"
 dependencies = [
  "bitflags 2.5.0",
  "downcast-rs",
@@ -3221,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
+checksum = "105b1842da6554f91526c14a2a2172897b7f745a805d62af4ce698706be79c12"
 dependencies = [
  "dlib",
  "libc",
@@ -3235,9 +4635,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3252,6 +4652,119 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "wgpu"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot 0.12.3",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.5.0",
+ "cfg_aliases 0.1.1",
+ "codespan-reporting",
+ "indexmap 2.2.6",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "web-sys",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1a4924366df7ab41a5d8546d6534f1f33231aa5b3f72b9930e300f254e39c3"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.5.0",
+ "block",
+ "cfg_aliases 0.1.1",
+ "core-graphics-types",
+ "d3d12",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hassle-rs",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.3",
+ "log",
+ "metal",
+ "naga",
+ "ndk-sys",
+ "objc",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "winapi",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
+dependencies = [
+ "bitflags 2.5.0",
+ "js-sys",
+ "web-sys",
+]
+
+[[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"
@@ -3283,6 +4796,20 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "window_clipboard"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d692d46038c433f9daee7ad8757e002a4248c20b0a3fbc991d99521d3bcb6d"
+dependencies = [
+ "clipboard-win",
+ "clipboard_macos",
+ "clipboard_wayland",
+ "clipboard_x11",
+ "raw-window-handle",
+ "thiserror",
+]
 
 [[package]]
 name = "windows"
@@ -3520,7 +5047,7 @@ dependencies = [
  "bitflags 2.5.0",
  "bytemuck",
  "calloop 0.12.4",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "core-foundation",
  "core-graphics",
  "cursor-icon",
@@ -3531,21 +5058,22 @@ dependencies = [
  "memmap2 0.9.4",
  "ndk",
  "ndk-sys",
- "objc2",
+ "objc2 0.4.1",
  "once_cell",
  "orbclient",
  "percent-encoding",
  "raw-window-handle",
  "redox_syscall 0.3.5",
  "rustix",
- "smithay-client-toolkit",
+ "sctk-adwaita",
+ "smithay-client-toolkit 0.18.1",
  "smol_str",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-protocols-plasma",
  "web-sys",
  "web-time",
@@ -3566,9 +5094,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -3670,15 +5198,36 @@ dependencies = [
 
 [[package]]
 name = "xkeysym"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "xml-rs"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
+
+[[package]]
+name = "yazi"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
+
+[[package]]
+name = "zeno"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
 
 [[package]]
 name = "zerocopy"
@@ -3697,14 +5246,14 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
@@ -3717,5 +5266,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.66",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,6 +2898,7 @@ version = "0.0.2"
 dependencies = [
  "bitflags 2.5.0",
  "futures",
+ "indexmap 2.2.6",
  "num_enum",
  "pinnacle-api-defs",
  "pinnacle-api-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -938,6 +938,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1253,27 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "from_variants"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e859c8f2057687618905dbe99fc76e836e0a69738865ef90e46fc214a41bbf2"
+dependencies = [
+ "from_variants_impl",
+]
+
+[[package]]
+name = "from_variants_impl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a5e644a80e6d96b2b4910fa7993301d7b7926c045b475b62202b20a36ce69e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "futures"
@@ -1833,6 +1889,12 @@ dependencies = [
  "dispatch",
  "objc2 0.4.1",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
@@ -3614,6 +3676,7 @@ dependencies = [
 name = "snowcap-api"
 version = "0.1.0"
 dependencies = [
+ "from_variants",
  "futures",
  "snowcap-api-defs",
  "tokio",
@@ -3697,6 +3760,12 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,7 +3588,6 @@ dependencies = [
 [[package]]
 name = "snowcap"
 version = "0.0.1"
-source = "git+https://github.com/pinnacle-comp/snowcap?rev=acb0e29#acb0e29b3da3cdc9a701a6e3819afe56cce58e34"
 dependencies = [
  "anyhow",
  "futures",
@@ -3614,7 +3613,6 @@ dependencies = [
 [[package]]
 name = "snowcap-api"
 version = "0.1.0"
-source = "git+https://github.com/pinnacle-comp/snowcap?rev=acb0e29#acb0e29b3da3cdc9a701a6e3819afe56cce58e34"
 dependencies = [
  "futures",
  "snowcap-api-defs",
@@ -3629,7 +3627,6 @@ dependencies = [
 [[package]]
 name = "snowcap-api-defs"
 version = "0.1.0"
-source = "git+https://github.com/pinnacle-comp/snowcap?rev=acb0e29#acb0e29b3da3cdc9a701a6e3819afe56cce58e34"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "api/rust/pinnacle-api-macros",
     "wlcs_pinnacle",
 ]
+exclude = ["snowcap"]
 
 [workspace.package]
 authors = ["Ottatop <ottatop1227@gmail.com>"]
@@ -118,8 +119,8 @@ gag = "1.0.0"
 drm-sys = "0.7.0"
 libdisplay-info-sys = { git = "https://github.com/Smithay/libdisplay-info-rs", rev = "a482d0d" }
 indexmap = "2.2.6"
-snowcap = { git = "https://github.com/pinnacle-comp/snowcap", rev = "acb0e29", optional = true }
-snowcap-api = { git = "https://github.com/pinnacle-comp/snowcap", rev = "acb0e29", optional = true }
+snowcap = { path = "./snowcap", optional = true }
+snowcap-api = { path = "./snowcap/api/rust", optional = true }
 
 [build-dependencies]
 vergen = { version = "8.3.1", features = ["git", "gitcl", "rustc", "cargo", "si"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/pinnacle-comp/pinnacle/"
 
 [workspace.dependencies]
 # Tokio
-tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"]}
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"]}
 tokio-stream = { version = "0.1.15", features = ["net"] }
 # gRPC
 prost = "0.12.4"
@@ -113,11 +113,13 @@ pinnacle-api-defs = { workspace = true }
 dircpy = { workspace = true }
 chrono = "0.4.38"
 bytemuck = "1.16.0"
-pinnacle-api = { path = "./api/rust" }
+pinnacle-api = { path = "./api/rust", default-features = false }
 gag = "1.0.0"
 drm-sys = "0.7.0"
 libdisplay-info-sys = { git = "https://github.com/Smithay/libdisplay-info-rs", rev = "a482d0d" }
 indexmap = "2.2.6"
+snowcap = { git = "https://github.com/pinnacle-comp/snowcap", rev = "acb0e29", optional = true }
+snowcap-api = { git = "https://github.com/pinnacle-comp/snowcap", rev = "acb0e29", optional = true }
 
 [build-dependencies]
 vergen = { version = "8.3.1", features = ["git", "gitcl", "rustc", "cargo", "si"] }
@@ -126,11 +128,13 @@ vergen = { version = "8.3.1", features = ["git", "gitcl", "rustc", "cargo", "si"
 temp-env = "0.3.6"
 tempfile = { workspace = true }
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }
-pinnacle = { path = ".", features = ["wlcs"] }
-pinnacle-api = { path = "./api/rust" }
+pinnacle = { path = ".", features = ["wlcs"], default-features = false }
+pinnacle-api = { path = "./api/rust", default-features = false }
 
 [features]
+default = ["snowcap"]
+snowcap = ["pinnacle-api/snowcap", "dep:snowcap", "dep:snowcap-api"]
 testing = [
     "smithay/renderer_test",
 ]
-wlcs = [ "testing" ]
+wlcs = ["testing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ bitflags = "2.5.0"
 clap = { version = "4.5.4", features = ["derive"] }
 dircpy = "0.3.16"
 tempfile = "3.10.1"
+indexmap = "2.2.6"
 
 [workspace.dependencies.smithay]
 git = "https://github.com/Smithay/smithay"
@@ -118,7 +119,7 @@ pinnacle-api = { path = "./api/rust", default-features = false }
 gag = "1.0.0"
 drm-sys = "0.7.0"
 libdisplay-info-sys = { git = "https://github.com/Smithay/libdisplay-info-rs", rev = "a482d0d" }
-indexmap = "2.2.6"
+indexmap = { workspace = true }
 snowcap = { path = "./snowcap", optional = true }
 snowcap-api = { path = "./snowcap/api/rust", optional = true }
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,3 @@
-- Re-add raising file descriptor limit
-    - Like an idiot I managed to remove that sometime and not add it back
 - Provide scale and transform on new window/layer
 
 Problems:
@@ -8,4 +6,3 @@ Problems:
 - Xwayland popups are screwed when the output is not at (0, 0)
 - Dragging an xwayland window to another output and closing a nested right click menu closes the whole
   right click menu because the keyboard focus is getting updated on the original output.
-- Transactions don't render floating windows

--- a/api/lua/examples/default/default_config.lua
+++ b/api/lua/examples/default/default_config.lua
@@ -34,12 +34,18 @@ require("pinnacle").setup(function(Pinnacle)
     -- mod_key + alt + q = Quit Pinnacle
     Input.keybind({ mod_key, "alt" }, "q", function()
         Pinnacle.quit()
-    end)
+    end, {
+        group = "Compositor",
+        description = "Quit Pinnacle",
+    })
 
     -- mod_key + alt + r = Reload config
     Input.keybind({ mod_key, "alt" }, "r", function()
         Pinnacle.reload_config()
-    end)
+    end, {
+        group = "Compositor",
+        description = "Reload the config",
+    })
 
     -- mod_key + alt + c = Close window
     Input.keybind({ mod_key, "alt" }, "c", function()
@@ -47,12 +53,18 @@ require("pinnacle").setup(function(Pinnacle)
         if focused then
             focused:close()
         end
-    end)
+    end, {
+        group = "Window",
+        description = "Close the focused window",
+    })
 
     -- mod_key + alt + Return = Spawn `terminal`
     Input.keybind({ mod_key }, key.Return, function()
         Process.spawn(terminal)
-    end)
+    end, {
+        group = "Process",
+        description = "Spawn `alacritty`",
+    })
 
     -- mod_key + alt + space = Toggle floating
     Input.keybind({ mod_key, "alt" }, key.space, function()
@@ -61,7 +73,10 @@ require("pinnacle").setup(function(Pinnacle)
             focused:toggle_floating()
             focused:raise()
         end
-    end)
+    end, {
+        group = "Window",
+        description = "Toggle floating on the focused window",
+    })
 
     -- mod_key + f = Toggle fullscreen
     Input.keybind({ mod_key }, "f", function()
@@ -70,7 +85,10 @@ require("pinnacle").setup(function(Pinnacle)
             focused:toggle_fullscreen()
             focused:raise()
         end
-    end)
+    end, {
+        group = "Window",
+        description = "Toggle fullscreen on the focused window",
+    })
 
     -- mod_key + m = Toggle maximized
     Input.keybind({ mod_key }, "m", function()
@@ -79,7 +97,10 @@ require("pinnacle").setup(function(Pinnacle)
             focused:toggle_maximized()
             focused:raise()
         end
-    end)
+    end, {
+        group = "Window",
+        description = "Toggle maximized on the focused window",
+    })
 
     ----------------------
     -- Tags and Outputs --
@@ -109,12 +130,18 @@ require("pinnacle").setup(function(Pinnacle)
         -- mod_key + 1-5 = Switch to tags 1-5
         Input.keybind({ mod_key }, tag_name, function()
             Tag.get(tag_name):switch_to()
-        end)
+        end, {
+            group = "Tag",
+            description = "Switch to tag " .. tag_name,
+        })
 
         -- mod_key + shift + 1-5 = Toggle tags 1-5
         Input.keybind({ mod_key, "shift" }, tag_name, function()
             Tag.get(tag_name):toggle_active()
-        end)
+        end, {
+            group = "Tag",
+            description = "Toggle tag " .. tag_name,
+        })
 
         -- mod_key + alt + 1-5 = Move window to tags 1-5
         Input.keybind({ mod_key, "alt" }, tag_name, function()
@@ -122,7 +149,10 @@ require("pinnacle").setup(function(Pinnacle)
             if focused then
                 focused:move_to_tag(Tag.get(tag_name) --[[@as TagHandle]])
             end
-        end)
+        end, {
+            group = "Tag",
+            description = "Move the focused window to tag " .. tag_name,
+        })
 
         -- mod_key + shift + alt + 1-5 = Toggle tags 1-5 on window
         Input.keybind({ mod_key, "shift", "alt" }, tag_name, function()
@@ -130,7 +160,10 @@ require("pinnacle").setup(function(Pinnacle)
             if focused then
                 focused:toggle_tag(Tag.get(tag_name) --[[@as TagHandle]])
             end
-        end)
+        end, {
+            group = "Tag",
+            description = "Toggle tag " .. tag_name .. " on the focused window",
+        })
     end
 
     --------------------
@@ -226,7 +259,10 @@ require("pinnacle").setup(function(Pinnacle)
                 Layout.request_layout(focused_op)
             end
         end
-    end)
+    end, {
+        group = "Layout",
+        description = "Cycle the layout forward on the first active tag",
+    })
 
     -- mod_key + shift + space = Cycle backward one layout on the focused output
     Input.keybind({ mod_key, "shift" }, key.space, function()
@@ -257,7 +293,10 @@ require("pinnacle").setup(function(Pinnacle)
                 Layout.request_layout(focused_op)
             end
         end
-    end)
+    end, {
+        group = "Layout",
+        description = "Cycle the layout backward on the first active tag",
+    })
 
     Input.set_libinput_settings({
         tap = true,

--- a/api/lua/pinnacle/grpc/defs.lua
+++ b/api/lua/pinnacle/grpc/defs.lua
@@ -258,6 +258,8 @@ local pinnacle_input_v0alpha1_Modifier = {
 ---@field modifiers pinnacle.input.v0alpha1.Modifier[]?
 ---@field raw_code integer?
 ---@field xkb_name string?
+---@field group string?
+---@field description string?
 
 ---@class pinnacle.input.v0alpha1.SetKeybindResponse
 
@@ -273,6 +275,18 @@ local pinnacle_input_v0alpha1_SetMousebindRequest_MouseEdge = {
 ---@field edge pinnacle.input.v0alpha1.SetMousebindRequest.MouseEdge?
 
 ---@class pinnacle.input.v0alpha1.SetMousebindResponse
+
+---@class pinnacle.input.v0alpha1.KeybindDescriptionsRequest
+
+---@class pinnacle.input.v0alpha1.KeybindDescriptionsResponse
+---@field descriptions pinnacle.input.v0alpha1.KeybindDescription[]?
+
+---@class pinnacle.input.v0alpha1.KeybindDescription
+---@field modifiers pinnacle.input.v0alpha1.Modifier[]?
+---@field raw_code integer?
+---@field xkb_name string?
+---@field group string?
+---@field description string?
 
 ---@class SetXkbConfigRequest
 ---@field rules string?
@@ -727,6 +741,13 @@ defs.pinnacle = {
                     method = "SetMousebind",
                     request = "pinnacle.input.v0alpha1.SetMousebindRequest",
                     response = "pinnacle.input.v0alpha1.SetMousebindResponse",
+                },
+                ---@type GrpcRequestArgs
+                KeybindDescriptions = {
+                    service = "pinnacle.input.v0alpha1.InputService",
+                    method = "KeybindDescriptions",
+                    request = "pinnacle.input.v0alpha1.KeybindDescriptionsRequest",
+                    response = "pinnacle.input.v0alpha1.KeybindDescriptionsResponse",
                 },
                 ---@type GrpcRequestArgs
                 SetXkbConfig = {

--- a/api/lua/pinnacle/input.lua
+++ b/api/lua/pinnacle/input.lua
@@ -74,6 +74,10 @@ local input = {
 }
 input.mouse_button_values = mouse_button_values
 
+---@class KeybindInfo
+---@field group string? The group to place this keybind in. Used for the keybind list.
+---@field description string? The description of this keybind. Used for the keybind list.
+
 ---Set a keybind. If called with an already existing keybind, it gets replaced.
 ---
 ---You must provide three arguments:
@@ -111,7 +115,8 @@ input.mouse_button_values = mouse_button_values
 ---@param mods Modifier[] The modifiers that need to be held down for the bind to trigger
 ---@param key Key | string The key used to trigger the bind
 ---@param action fun() The function to run when the bind is triggered
-function input.keybind(mods, key, action)
+---@param keybind_info KeybindInfo?
+function input.keybind(mods, key, action, keybind_info)
     local raw_code = nil
     local xkb_name = nil
 
@@ -130,6 +135,8 @@ function input.keybind(mods, key, action)
         modifiers = mod_values,
         raw_code = raw_code,
         xkb_name = xkb_name,
+        group = keybind_info and keybind_info.group,
+        description = keybind_info and keybind_info.description,
     }, action)
 end
 
@@ -163,6 +170,31 @@ function input.mousebind(mods, button, edge, action)
         button = mouse_button_values[button],
         edge = edge,
     }, action)
+end
+
+---@class KeybindDescription
+---@field modifiers Modifier[]
+---@field raw_code integer
+---@field xkb_name string
+---@field group string?
+---@field description string?
+
+---Get all keybinds along with their descriptions
+---
+---@return KeybindDescription[]
+function input.keybind_descriptions()
+    ---@type pinnacle.input.v0alpha1.KeybindDescriptionsResponse
+    local descs = client.unary_request(input_service.KeybindDescriptions, {})
+    local descs = descs.descriptions or {}
+
+    local ret = {}
+
+    for _, desc in ipairs(descs) do
+        desc.modifiers = desc.modifiers or {}
+        table.insert(ret, desc)
+    end
+
+    return ret
 end
 
 ---@class XkbConfig

--- a/api/protocol/pinnacle/input/v0alpha1/input.proto
+++ b/api/protocol/pinnacle/input/v0alpha1/input.proto
@@ -18,8 +18,24 @@ message SetKeybindRequest {
     uint32 raw_code = 2;
     string xkb_name = 3;
   }
+  optional string group = 4;
+  optional string description = 5;
 }
 message SetKeybindResponse {}
+
+message KeybindDescriptionsRequest {}
+
+message KeybindDescriptionsResponse {
+  repeated KeybindDescription descriptions = 1;
+}
+
+message KeybindDescription {
+  repeated Modifier modifiers = 1;
+  optional uint32 raw_code = 2;
+  optional string xkb_name = 3;
+  optional string group = 4;
+  optional string description = 5;
+}
 
 message SetMousebindRequest {
   repeated Modifier modifiers = 1;
@@ -130,6 +146,8 @@ message SetLibinputSettingRequest {
 service InputService {
   rpc SetKeybind(SetKeybindRequest) returns (stream SetKeybindResponse);
   rpc SetMousebind(SetMousebindRequest) returns (stream SetMousebindResponse);
+
+  rpc KeybindDescriptions(KeybindDescriptionsRequest) returns (KeybindDescriptionsResponse);
 
   rpc SetXkbConfig(SetXkbConfigRequest) returns (google.protobuf.Empty);
   rpc SetRepeatRate(SetRepeatRateRequest) returns (google.protobuf.Empty);

--- a/api/rust/Cargo.toml
+++ b/api/rust/Cargo.toml
@@ -22,6 +22,7 @@ xkbcommon = { workspace = true }
 rand = "0.8.5"
 bitflags = { workspace = true }
 snowcap-api = { path = "../../snowcap/api/rust", optional = true }
+indexmap = { workspace = true }
 
 [features]
 default = ["snowcap"]

--- a/api/rust/Cargo.toml
+++ b/api/rust/Cargo.toml
@@ -21,7 +21,7 @@ num_enum = "0.7.2"
 xkbcommon = { workspace = true }
 rand = "0.8.5"
 bitflags = { workspace = true }
-snowcap-api = { git = "https://github.com/pinnacle-comp/snowcap", rev = "acb0e29", optional = true }
+snowcap-api = { path = "../../snowcap/api/rust", optional = true }
 
 [features]
 default = ["snowcap"]

--- a/api/rust/Cargo.toml
+++ b/api/rust/Cargo.toml
@@ -21,3 +21,8 @@ num_enum = "0.7.2"
 xkbcommon = { workspace = true }
 rand = "0.8.5"
 bitflags = { workspace = true }
+snowcap-api = { git = "https://github.com/pinnacle-comp/snowcap", rev = "acb0e29", optional = true }
+
+[features]
+default = ["snowcap"]
+snowcap = ["dep:snowcap-api"]

--- a/api/rust/examples/default_config/for_copying/Cargo.toml
+++ b/api/rust/examples/default_config/for_copying/Cargo.toml
@@ -4,4 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-pinnacle-api = { git = "http://github.com/pinnacle-comp/pinnacle" }
+pinnacle-api = { git = "http://github.com/pinnacle-comp/pinnacle", default-features = false }
+
+[features]
+default = ["snowcap"]
+snowcap = ["pinnacle-api/snowcap"]

--- a/api/rust/examples/default_config/main.rs
+++ b/api/rust/examples/default_config/main.rs
@@ -19,11 +19,8 @@ use snowcap_api::widget::{Alignment, Column, Container, Length, Text};
 // Pinnacle needs to perform some setup before and after your config.
 // The `#[pinnacle_api::config(modules)]` attribute does so and
 // will bind all the config structs to the provided identifier.
-// #[pinnacle_api::config(modules)]
-#[pinnacle_api::tokio::main]
+#[pinnacle_api::config(modules)]
 async fn main() {
-    let (modules, __recv) = pinnacle_api::connect().await.unwrap();
-
     // Deconstruct to get all the APIs.
     #[cfg(feature = "snowcap")]
     #[allow(unused_variables)]
@@ -38,7 +35,7 @@ async fn main() {
         render,
         snowcap,
         ..
-    } = modules.clone();
+    } = modules;
 
     #[cfg(not(feature = "snowcap"))]
     #[allow(unused_variables)]
@@ -52,7 +49,7 @@ async fn main() {
         layout,
         render,
         ..
-    } = modules.clone();
+    } = modules;
 
     let mod_key = Mod::Ctrl;
 
@@ -314,6 +311,4 @@ async fn main() {
     })));
 
     process.spawn_once([terminal]);
-
-    pinnacle_api::listen(modules, __recv).await;
 }

--- a/api/rust/examples/default_config/main.rs
+++ b/api/rust/examples/default_config/main.rs
@@ -11,10 +11,6 @@ use pinnacle_api::{
     input::{Mod, MouseButton, MouseEdge},
     ApiModules,
 };
-#[cfg(feature = "snowcap")]
-use snowcap_api::layer::{ExclusiveZone, KeyboardInteractivity, ZLayer};
-#[cfg(feature = "snowcap")]
-use snowcap_api::widget::{Alignment, Column, Container, Length, Text};
 
 // Pinnacle needs to perform some setup before and after your config.
 // The `#[pinnacle_api::config(modules)]` attribute does so and
@@ -76,36 +72,7 @@ async fn main() {
     // `mod_key + alt + q` quits Pinnacle
     input.keybind([mod_key, Mod::Alt], 'q', || {
         #[cfg(feature = "snowcap")]
-        {
-            let widget = Container::new(Column::new_with_children([
-                Text::new("Quit Pinnacle?").into(),
-                Text::new("Press ENTER to confirm.").into(),
-            ]))
-            .with_vertical_alignment(Alignment::Center)
-            .with_horizontal_alignment(Alignment::Center)
-            .with_width(Length::Fill)
-            .with_height(Length::Fill)
-            .with_border_thickness(4.0)
-            .with_border_radius(16.0);
-
-            snowcap
-                .new_widget(
-                    widget.into(),
-                    200,
-                    100,
-                    None,
-                    KeyboardInteractivity::Exclusive,
-                    ExclusiveZone::Respect,
-                    ZLayer::Overlay,
-                )
-                .on_key_press(|widget, key, _mods| {
-                    if key == Keysym::Return {
-                        pinnacle.quit();
-                    } else {
-                        widget.close();
-                    }
-                });
-        }
+        snowcap.integration.quit_prompt().show();
 
         #[cfg(not(feature = "snowcap"))]
         pinnacle.quit();

--- a/api/rust/examples/default_config/main.rs
+++ b/api/rust/examples/default_config/main.rs
@@ -19,7 +19,6 @@ use pinnacle_api::{
 #[pinnacle_api::config(modules)]
 async fn main() {
     // Deconstruct to get all the APIs.
-    #[cfg(feature = "snowcap")]
     #[allow(unused_variables)]
     let ApiModules {
         pinnacle,
@@ -30,21 +29,8 @@ async fn main() {
         tag,
         layout,
         render,
+        #[cfg(feature = "snowcap")]
         snowcap,
-        ..
-    } = modules;
-
-    #[cfg(not(feature = "snowcap"))]
-    #[allow(unused_variables)]
-    let ApiModules {
-        pinnacle,
-        process,
-        window,
-        input,
-        output,
-        tag,
-        layout,
-        render,
         ..
     } = modules;
 
@@ -71,11 +57,11 @@ async fn main() {
     //------------------------
 
     // `mod_key + s` shows the keybind overlay
+    #[cfg(feature = "snowcap")]
     input.keybind(
         [mod_key],
         's',
         || {
-            #[cfg(feature = "snowcap")]
             snowcap.integration.keybind_overlay().show();
         },
         KeybindInfo {
@@ -91,7 +77,6 @@ async fn main() {
         || {
             #[cfg(feature = "snowcap")]
             snowcap.integration.quit_prompt().show();
-
             #[cfg(not(feature = "snowcap"))]
             pinnacle.quit();
         },

--- a/api/rust/examples/default_config/main.rs
+++ b/api/rust/examples/default_config/main.rs
@@ -1,4 +1,5 @@
 use pinnacle_api::input::libinput::LibinputSetting;
+use pinnacle_api::input::KeybindInfo;
 use pinnacle_api::layout::{
     CornerLayout, CornerLocation, CyclingLayoutManager, DwindleLayout, FairLayout, MasterSide,
     MasterStackLayout, SpiralLayout,
@@ -51,6 +52,15 @@ async fn main() {
 
     let terminal = "alacritty";
 
+    input.keybind(
+        [mod_key],
+        'i',
+        || {
+            dbg!(input.keybind_descriptions().collect::<Vec<_>>());
+        },
+        None,
+    );
+
     //------------------------
     // Mousebinds            |
     //------------------------
@@ -70,54 +80,110 @@ async fn main() {
     //------------------------
 
     // `mod_key + alt + q` quits Pinnacle
-    input.keybind([mod_key, Mod::Alt], 'q', || {
-        #[cfg(feature = "snowcap")]
-        snowcap.integration.quit_prompt().show();
+    input.keybind(
+        [mod_key, Mod::Alt],
+        'q',
+        || {
+            #[cfg(feature = "snowcap")]
+            snowcap.integration.quit_prompt().show();
 
-        #[cfg(not(feature = "snowcap"))]
-        pinnacle.quit();
-    });
+            #[cfg(not(feature = "snowcap"))]
+            pinnacle.quit();
+        },
+        KeybindInfo {
+            group: Some("Compositor".into()),
+            description: Some("Quit Pinnacle".into()),
+        },
+    );
 
     // `mod_key + alt + r` reloads the config
-    input.keybind([mod_key, Mod::Alt], 'r', || {
-        pinnacle.reload_config();
-    });
+    input.keybind(
+        [mod_key, Mod::Alt],
+        'r',
+        || {
+            pinnacle.reload_config();
+        },
+        KeybindInfo {
+            group: Some("Compositor".into()),
+            description: Some("Reload the config".into()),
+        },
+    );
 
     // `mod_key + alt + c` closes the focused window
-    input.keybind([mod_key, Mod::Alt], 'c', || {
-        if let Some(window) = window.get_focused() {
-            window.close();
-        }
-    });
+    input.keybind(
+        [mod_key, Mod::Alt],
+        'c',
+        || {
+            if let Some(window) = window.get_focused() {
+                window.close();
+            }
+        },
+        KeybindInfo {
+            group: Some("Window".into()),
+            description: Some("Close the focused window".into()),
+        },
+    );
 
     // `mod_key + Return` spawns a terminal
-    input.keybind([mod_key], Keysym::Return, move || {
-        process.spawn([terminal]);
-    });
+    input.keybind(
+        [mod_key],
+        Keysym::Return,
+        move || {
+            process.spawn([terminal]);
+        },
+        KeybindInfo {
+            group: Some("Process".into()),
+            description: Some("Spawn `alacritty`".into()),
+        },
+    );
 
     // `mod_key + alt + space` toggles floating
-    input.keybind([mod_key, Mod::Alt], Keysym::space, || {
-        if let Some(window) = window.get_focused() {
-            window.toggle_floating();
-            window.raise();
-        }
-    });
+    input.keybind(
+        [mod_key, Mod::Alt],
+        Keysym::space,
+        || {
+            if let Some(window) = window.get_focused() {
+                window.toggle_floating();
+                window.raise();
+            }
+        },
+        KeybindInfo {
+            group: Some("Window".into()),
+            description: Some("Toggle floating on the focused window".into()),
+        },
+    );
 
     // `mod_key + f` toggles fullscreen
-    input.keybind([mod_key], 'f', || {
-        if let Some(window) = window.get_focused() {
-            window.toggle_fullscreen();
-            window.raise();
-        }
-    });
+    input.keybind(
+        [mod_key],
+        'f',
+        || {
+            if let Some(window) = window.get_focused() {
+                window.toggle_fullscreen();
+                window.raise();
+            }
+        },
+        KeybindInfo {
+            group: Some("Window".into()),
+            description: Some("Toggle fullscreen on the focused window".into()),
+        },
+    );
 
     // `mod_key + m` toggles maximized
-    input.keybind([mod_key], 'm', || {
-        if let Some(window) = window.get_focused() {
-            window.toggle_maximized();
-            window.raise();
-        }
-    });
+    input.keybind(
+        [mod_key],
+        'm',
+        || {
+            if let Some(window) = window.get_focused() {
+                window.toggle_maximized();
+                window.raise();
+            }
+        },
+        KeybindInfo {
+            group: Some("Window".into()),
+            description: Some("Toggle maximized on the focused window".into()),
+        },
+    );
 
     //------------------------
     // Window rules          |
@@ -200,32 +266,48 @@ async fn main() {
     let mut layout_requester_clone = layout_requester.clone();
 
     // `mod_key + space` cycles to the next layout
-    input.keybind([mod_key], Keysym::space, move || {
-        let Some(focused_op) = output.get_focused() else { return };
-        let Some(first_active_tag) = focused_op.tags().batch_find(
-            |tg| Box::pin(tg.active_async()),
-            |active| active == &Some(true),
-        ) else {
-            return;
-        };
+    input.keybind(
+        [mod_key],
+        Keysym::space,
+        move || {
+            let Some(focused_op) = output.get_focused() else { return };
+            let Some(first_active_tag) = focused_op.tags().batch_find(
+                |tg| Box::pin(tg.active_async()),
+                |active| active == &Some(true),
+            ) else {
+                return;
+            };
 
-        layout_requester.cycle_layout_forward(&first_active_tag);
-        layout_requester.request_layout_on_output(&focused_op);
-    });
+            layout_requester.cycle_layout_forward(&first_active_tag);
+            layout_requester.request_layout_on_output(&focused_op);
+        },
+        KeybindInfo {
+            group: Some("Layout".into()),
+            description: Some("Cycle the layout forward on the first active tag".into()),
+        },
+    );
 
     // `mod_key + shift + space` cycles to the previous layout
-    input.keybind([mod_key, Mod::Shift], Keysym::space, move || {
-        let Some(focused_op) = output.get_focused() else { return };
-        let Some(first_active_tag) = focused_op.tags().batch_find(
-            |tg| Box::pin(tg.active_async()),
-            |active| active == &Some(true),
-        ) else {
-            return;
-        };
+    input.keybind(
+        [mod_key, Mod::Shift],
+        Keysym::space,
+        move || {
+            let Some(focused_op) = output.get_focused() else { return };
+            let Some(first_active_tag) = focused_op.tags().batch_find(
+                |tg| Box::pin(tg.active_async()),
+                |active| active == &Some(true),
+            ) else {
+                return;
+            };
 
-        layout_requester_clone.cycle_layout_backward(&first_active_tag);
-        layout_requester_clone.request_layout_on_output(&focused_op);
-    });
+            layout_requester_clone.cycle_layout_backward(&first_active_tag);
+            layout_requester_clone.request_layout_on_output(&focused_op);
+        },
+        KeybindInfo {
+            group: Some("Layout".into()),
+            description: Some("Cycle the layout backward on the first active tag".into()),
+        },
+    );
 
     //------------------------
     // Tags                  |
@@ -238,36 +320,68 @@ async fn main() {
 
     for tag_name in tag_names {
         // `mod_key + 1-5` switches to tag "1" to "5"
-        input.keybind([mod_key], tag_name, move || {
-            if let Some(tg) = tag.get(tag_name) {
-                tg.switch_to();
-            }
-        });
+        input.keybind(
+            [mod_key],
+            tag_name,
+            move || {
+                if let Some(tg) = tag.get(tag_name) {
+                    tg.switch_to();
+                }
+            },
+            KeybindInfo {
+                group: Some("Tag".into()),
+                description: Some(format!("Switch to tag {tag_name}")),
+            },
+        );
 
         // `mod_key + shift + 1-5` toggles tag "1" to "5"
-        input.keybind([mod_key, Mod::Shift], tag_name, move || {
-            if let Some(tg) = tag.get(tag_name) {
-                tg.toggle_active();
-            }
-        });
+        input.keybind(
+            [mod_key, Mod::Shift],
+            tag_name,
+            move || {
+                if let Some(tg) = tag.get(tag_name) {
+                    tg.toggle_active();
+                }
+            },
+            KeybindInfo {
+                group: Some("Tag".into()),
+                description: Some(format!("Toggle tag {tag_name}")),
+            },
+        );
 
         // `mod_key + alt + 1-5` moves the focused window to tag "1" to "5"
-        input.keybind([mod_key, Mod::Alt], tag_name, move || {
-            if let Some(tg) = tag.get(tag_name) {
-                if let Some(win) = window.get_focused() {
-                    win.move_to_tag(&tg);
+        input.keybind(
+            [mod_key, Mod::Alt],
+            tag_name,
+            move || {
+                if let Some(tg) = tag.get(tag_name) {
+                    if let Some(win) = window.get_focused() {
+                        win.move_to_tag(&tg);
+                    }
                 }
-            }
-        });
+            },
+            KeybindInfo {
+                group: Some("Tag".into()),
+                description: Some(format!("Move the focused window to tag {tag_name}")),
+            },
+        );
 
         // `mod_key + shift + alt + 1-5` toggles tag "1" to "5" on the focused window
-        input.keybind([mod_key, Mod::Shift, Mod::Alt], tag_name, move || {
-            if let Some(tg) = tag.get(tag_name) {
-                if let Some(win) = window.get_focused() {
-                    win.toggle_tag(&tg);
+        input.keybind(
+            [mod_key, Mod::Shift, Mod::Alt],
+            tag_name,
+            move || {
+                if let Some(tg) = tag.get(tag_name) {
+                    if let Some(win) = window.get_focused() {
+                        win.toggle_tag(&tg);
+                    }
                 }
-            }
-        });
+            },
+            KeybindInfo {
+                group: Some("Tag".into()),
+                description: Some(format!("Toggle tag {tag_name} on the focused window")),
+            },
+        );
     }
 
     input.set_libinput_setting(LibinputSetting::Tap(true));

--- a/api/rust/examples/default_config/main.rs
+++ b/api/rust/examples/default_config/main.rs
@@ -52,15 +52,6 @@ async fn main() {
 
     let terminal = "alacritty";
 
-    input.keybind(
-        [mod_key],
-        'i',
-        || {
-            dbg!(input.keybind_descriptions().collect::<Vec<_>>());
-        },
-        None,
-    );
-
     //------------------------
     // Mousebinds            |
     //------------------------
@@ -78,6 +69,20 @@ async fn main() {
     //------------------------
     // Keybinds              |
     //------------------------
+
+    // `mod_key + s` shows the keybind overlay
+    input.keybind(
+        [mod_key],
+        's',
+        || {
+            #[cfg(feature = "snowcap")]
+            snowcap.integration.keybind_overlay().show();
+        },
+        KeybindInfo {
+            group: Some("Compositor".into()),
+            description: Some("Show the keybind overlay".into()),
+        },
+    );
 
     // `mod_key + alt + q` quits Pinnacle
     input.keybind(
@@ -133,7 +138,7 @@ async fn main() {
         },
         KeybindInfo {
             group: Some("Process".into()),
-            description: Some("Spawn `alacritty`".into()),
+            description: Some(format!("Spawn `{terminal}`")),
         },
     );
 

--- a/api/rust/examples/default_config/main.rs
+++ b/api/rust/examples/default_config/main.rs
@@ -11,13 +11,36 @@ use pinnacle_api::{
     input::{Mod, MouseButton, MouseEdge},
     ApiModules,
 };
+#[cfg(feature = "snowcap")]
+use snowcap_api::layer::{ExclusiveZone, KeyboardInteractivity, ZLayer};
+#[cfg(feature = "snowcap")]
+use snowcap_api::widget::{Alignment, Column, Container, Length, Text};
 
 // Pinnacle needs to perform some setup before and after your config.
 // The `#[pinnacle_api::config(modules)]` attribute does so and
 // will bind all the config structs to the provided identifier.
-#[pinnacle_api::config(modules)]
+// #[pinnacle_api::config(modules)]
+#[pinnacle_api::tokio::main]
 async fn main() {
+    let (modules, __recv) = pinnacle_api::connect().await.unwrap();
+
     // Deconstruct to get all the APIs.
+    #[cfg(feature = "snowcap")]
+    #[allow(unused_variables)]
+    let ApiModules {
+        pinnacle,
+        process,
+        window,
+        input,
+        output,
+        tag,
+        layout,
+        render,
+        snowcap,
+        ..
+    } = modules.clone();
+
+    #[cfg(not(feature = "snowcap"))]
     #[allow(unused_variables)]
     let ApiModules {
         pinnacle,
@@ -29,7 +52,7 @@ async fn main() {
         layout,
         render,
         ..
-    } = modules;
+    } = modules.clone();
 
     let mod_key = Mod::Ctrl;
 
@@ -55,6 +78,39 @@ async fn main() {
 
     // `mod_key + alt + q` quits Pinnacle
     input.keybind([mod_key, Mod::Alt], 'q', || {
+        #[cfg(feature = "snowcap")]
+        {
+            let widget = Container::new(Column::new_with_children([
+                Text::new("Quit Pinnacle?").into(),
+                Text::new("Press ENTER to confirm.").into(),
+            ]))
+            .with_vertical_alignment(Alignment::Center)
+            .with_horizontal_alignment(Alignment::Center)
+            .with_width(Length::Fill)
+            .with_height(Length::Fill)
+            .with_border_thickness(4.0)
+            .with_border_radius(16.0);
+
+            snowcap
+                .new_widget(
+                    widget.into(),
+                    200,
+                    100,
+                    None,
+                    KeyboardInteractivity::Exclusive,
+                    ExclusiveZone::Respect,
+                    ZLayer::Overlay,
+                )
+                .on_key_press(|widget, key, _mods| {
+                    if key == Keysym::Return {
+                        pinnacle.quit();
+                    } else {
+                        widget.close();
+                    }
+                });
+        }
+
+        #[cfg(not(feature = "snowcap"))]
         pinnacle.quit();
     });
 
@@ -258,4 +314,6 @@ async fn main() {
     })));
 
     process.spawn_once([terminal]);
+
+    pinnacle_api::listen(modules, __recv).await;
 }

--- a/api/rust/examples/default_config_no_snowcap/main.rs
+++ b/api/rust/examples/default_config_no_snowcap/main.rs
@@ -1,0 +1,1 @@
+../default_config/main.rs

--- a/api/rust/examples/default_config_no_snowcap/metaconfig.toml
+++ b/api/rust/examples/default_config_no_snowcap/metaconfig.toml
@@ -1,0 +1,46 @@
+# This metaconfig.toml file dictates what config Pinnacle will run.
+#
+# When running Pinnacle, the compositor will look in the following directories for a metaconfig.toml file,
+# in order from top to bottom:
+#     $PINNACLE_CONFIG_DIR
+#     $XDG_CONFIG_HOME/pinnacle/
+#     ~/.config/pinnacle/
+#
+# When Pinnacle finds a metaconfig.toml file, it will execute the command provided to `command`.
+# To use a Rust config, this should be changed to something like ["cargo", "run"].
+# 
+# Because configuration is done using an external process, if it ever crashes, you lose all of your keybinds.
+# The compositor will load the default config if that happens, but in the event that you don't have
+# the necessary dependencies for it to run, you may get softlocked.
+# In order prevent you from getting stuck in the compositor, you must define keybinds to reload your config
+# and kill Pinnacle.
+# 
+# More details on each setting can be found below.
+
+# The command Pinnacle will run on startup and when you reload your config.
+# Paths are relative to the directory the metaconfig.toml file is in.
+# This must be an array.
+command = ["cargo", "run", "--example", "default_config", "--no-default-features"]
+
+### Keybinds ###
+# Each keybind takes in a table with two fields: `modifiers` and `key`.
+# - `modifiers` can be one of "Ctrl", "Alt", "Shift", or "Super".
+# - `key` can be a string of any lowercase letter, number,
+#   "numN" where N is a number for numpad keys, or "esc"/"escape".
+# Support for any xkbcommon key is planned for a future update.
+
+# The keybind that will reload your config.
+reload_keybind = { modifiers = ["Ctrl", "Alt"], key = "r" }
+# The keybind that will kill Pinnacle.
+kill_keybind = { modifiers = ["Ctrl", "Alt", "Shift"], key = "escape" }
+
+### Socket directory ###
+# Pinnacle will open a Unix socket at `$XDG_RUNTIME_DIR` by default, falling back to `/tmp` if it doesn't exist.
+# If you want/need to change this, use the `socket_dir` setting set to the directory of your choosing.
+#
+# socket_dir = "/your/dir/here/"
+
+### Environment Variables ###
+# If you need to spawn your config with any environment variables, list them here.
+[envs]
+# key = "value"

--- a/api/rust/src/lib.rs
+++ b/api/rust/src/lib.rs
@@ -237,6 +237,7 @@ pub async fn connect() -> Result<(ApiModules, Receivers), Box<dyn std::error::Er
     tag.finish_init(modules.clone());
     layout.finish_init(modules.clone());
     signal.read().await.finish_init(modules.clone());
+    #[cfg(feature = "snowcap")]
     modules.snowcap.finish_init(modules.clone());
 
     #[cfg(feature = "snowcap")]

--- a/api/rust/src/lib.rs
+++ b/api/rust/src/lib.rs
@@ -85,6 +85,7 @@ use pinnacle::Pinnacle;
 use process::Process;
 use render::Render;
 use signal::SignalState;
+#[cfg(feature = "snowcap")]
 use snowcap::Snowcap;
 use tag::Tag;
 use tokio::{

--- a/api/rust/src/lib.rs
+++ b/api/rust/src/lib.rs
@@ -113,6 +113,8 @@ pub mod util;
 pub mod window;
 
 pub use pinnacle_api_macros::config;
+#[cfg(feature = "snowcap")]
+pub use snowcap_api;
 pub use tokio;
 pub use xkbcommon;
 

--- a/api/rust/src/snowcap.rs
+++ b/api/rust/src/snowcap.rs
@@ -12,6 +12,7 @@ pub mod integration;
 pub struct Snowcap {
     /// Create layer surface widgets.
     pub layer: &'static Layer,
+    /// Pinnacle integrations.
     pub integration: &'static Integration,
 }
 

--- a/api/rust/src/snowcap.rs
+++ b/api/rust/src/snowcap.rs
@@ -1,0 +1,29 @@
+//! The Snowcap widget system.
+//! // TODO: these docs
+
+use integration::Integration;
+use snowcap_api::layer::Layer;
+
+use crate::ApiModules;
+
+pub mod integration;
+
+/// Snowcap modules and Pinnacle integration.
+pub struct Snowcap {
+    /// Create layer surface widgets.
+    pub layer: &'static Layer,
+    pub integration: &'static Integration,
+}
+
+impl Snowcap {
+    pub(crate) fn new(layer: Layer) -> Self {
+        Self {
+            layer: Box::leak(Box::new(layer)),
+            integration: Box::leak(Box::new(Integration::new())),
+        }
+    }
+
+    pub(crate) fn finish_init(&self, api: ApiModules) {
+        self.integration.finish_init(api);
+    }
+}

--- a/api/rust/src/snowcap/integration.rs
+++ b/api/rust/src/snowcap/integration.rs
@@ -4,16 +4,20 @@
 
 use std::sync::OnceLock;
 
+use indexmap::IndexMap;
 use snowcap_api::{
     layer::{ExclusiveZone, KeyboardInteractivity, ZLayer},
     widget::{
         font::{Family, Font, Weight},
-        Alignment, Color, Column, Container, Length, Text,
+        Alignment, Color, Column, Container, Length, Padding, Row, Scrollable, Text, WidgetDef,
     },
 };
 use xkbcommon::xkb::Keysym;
 
-use crate::ApiModules;
+use crate::{
+    input::{KeybindDescription, Mod},
+    ApiModules,
+};
 
 /// Builtin widgets for Pinnacle.
 pub struct Integration {
@@ -44,6 +48,22 @@ impl Integration {
             font: Font::new_with_family(Family::Name("Ubuntu".into())),
             width: 220,
             height: 120,
+        }
+    }
+
+    /// Create the default keybind overlay.
+    ///
+    /// Some of its characteristics can be changed by setting its fields.
+    pub fn keybind_overlay(&self) -> KeybindOverlay {
+        KeybindOverlay {
+            api: self.api.get().cloned().unwrap(),
+            border_radius: 12.0,
+            border_thickness: 6.0,
+            background_color: [0.15, 0.15, 0.225, 0.8].into(),
+            border_color: [0.4, 0.4, 0.7].into(),
+            font: Font::new_with_family(Family::Name("Ubuntu".into())),
+            width: 700,
+            height: 500,
         }
     }
 }
@@ -110,6 +130,189 @@ impl QuitPrompt {
                 } else {
                     handle.close();
                 }
+            });
+    }
+}
+
+/// A keybind overlay.
+pub struct KeybindOverlay {
+    api: ApiModules,
+    /// The radius of the prompt's corners.
+    pub border_radius: f32,
+    /// The thickness of the prompt border.
+    pub border_thickness: f32,
+    /// The color of the prompt background.
+    pub background_color: Color,
+    /// The color of the prompt border.
+    pub border_color: Color,
+    /// The font of the prompt.
+    pub font: Font,
+    /// The height of the prompt.
+    pub width: u32,
+    /// The width of the prompt.
+    pub height: u32,
+}
+
+impl KeybindOverlay {
+    /// Show this keybind overlay.
+    pub fn show(&self) {
+        let descriptions = self.api.input.keybind_descriptions();
+
+        #[derive(PartialEq, Eq, Hash)]
+        struct KeybindRepr {
+            mods: Vec<Mod>,
+            name: String,
+        }
+
+        impl std::fmt::Display for KeybindRepr {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let bind = self
+                    .mods
+                    .iter()
+                    .map(|m| {
+                        // TODO: strum name or something
+                        match m {
+                            Mod::Shift => "Shift",
+                            Mod::Ctrl => "Ctrl",
+                            Mod::Alt => "Alt",
+                            Mod::Super => "Super",
+                        }
+                        .to_string()
+                    })
+                    .chain([self.name.clone()])
+                    .collect::<Vec<_>>()
+                    .join(" + ");
+                write!(f, "{bind}")
+            }
+        }
+
+        #[derive(Default)]
+        struct GroupData {
+            binds: IndexMap<KeybindRepr, Vec<String>>,
+        }
+
+        let mut groups = IndexMap::<Option<String>, GroupData>::new();
+
+        for desc in descriptions {
+            let KeybindDescription {
+                modifiers,
+                key_code: _,
+                xkb_name,
+                group,
+                description,
+            } = desc;
+
+            let repr = KeybindRepr {
+                mods: modifiers,
+                name: xkb_name,
+            };
+
+            let group = groups.entry(group).or_default();
+
+            let descs = group.binds.entry(repr).or_default();
+
+            if let Some(desc) = description {
+                descs.push(desc);
+            }
+        }
+
+        // List keybinds with no group last
+        if let Some(data) = groups.shift_remove(&None) {
+            groups.insert(None, data);
+        }
+
+        let sections = groups.into_iter().flat_map(|(group, data)| {
+            let group_title = Text::new(group.unwrap_or("Other".into()))
+                .font(self.font.clone().weight(Weight::Bold))
+                .size(19.0);
+
+            let binds = data.binds.into_iter().map(|(key, descs)| {
+                if descs.is_empty() {
+                    WidgetDef::from(Text::new(key.to_string()).font(self.font.clone()))
+                } else if descs.len() == 1 {
+                    Row::new_with_children([
+                        Text::new(key.to_string())
+                            .width(Length::FillPortion(1))
+                            .font(self.font.clone())
+                            .into(),
+                        Text::new(descs[0].clone())
+                            .width(Length::FillPortion(2))
+                            .font(self.font.clone())
+                            .into(),
+                    ])
+                    .into()
+                } else {
+                    let mut children = Vec::<WidgetDef>::new();
+                    children.push(
+                        Text::new(key.to_string() + ":")
+                            .font(self.font.clone())
+                            .into(),
+                    );
+
+                    for desc in descs {
+                        children.push(
+                            Text::new(format!("\t{}", desc))
+                                .font(self.font.clone())
+                                .into(),
+                        );
+                    }
+
+                    Column::new_with_children(children).into()
+                }
+            });
+
+            let mut children = Vec::<WidgetDef>::new();
+            children.push(group_title.into());
+            for widget in binds {
+                children.push(widget);
+            }
+            children.push(Text::new("").size(8.0).into()); // Spacing because I haven't impl'd that yet
+
+            children
+        });
+
+        let scrollable = Scrollable::new(Column::new_with_children(sections))
+            .width(Length::Fill)
+            .height(Length::Fill);
+
+        let widget = Container::new(Column::new_with_children([
+            Text::new("Keybinds")
+                .font(self.font.clone().weight(Weight::Bold))
+                .size(24.0)
+                .width(Length::Fill)
+                .into(),
+            Text::new("").size(8.0).into(), // Spacing because I haven't impl'd that yet
+            scrollable.into(),
+        ]))
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .padding(Padding {
+            top: 16.0,
+            right: 16.0,
+            bottom: 16.0,
+            left: 16.0,
+        })
+        .vertical_alignment(Alignment::Center)
+        .horizontal_alignment(Alignment::Center)
+        .border_radius(self.border_radius)
+        .border_thickness(self.border_thickness)
+        .border_color(self.border_color)
+        .background_color(self.background_color);
+
+        self.api
+            .snowcap
+            .layer
+            .new_widget(
+                widget,
+                self.width,
+                self.height,
+                None,
+                KeyboardInteractivity::Exclusive,
+                ExclusiveZone::Respect,
+                ZLayer::Top,
+            )
+            .on_key_press(|handle, _key, _mods| {
+                handle.close();
             });
     }
 }

--- a/api/rust/src/snowcap/integration.rs
+++ b/api/rust/src/snowcap/integration.rs
@@ -1,0 +1,115 @@
+//! Pinnacle-specific integrations with Snowcap.
+//!
+//! This module includes builtin widgets like the exit prompt and keybind list.
+
+use std::sync::OnceLock;
+
+use snowcap_api::{
+    layer::{ExclusiveZone, KeyboardInteractivity, ZLayer},
+    widget::{
+        font::{Family, Font, Weight},
+        Alignment, Color, Column, Container, Length, Text,
+    },
+};
+use xkbcommon::xkb::Keysym;
+
+use crate::ApiModules;
+
+/// Builtin widgets for Pinnacle.
+pub struct Integration {
+    api: OnceLock<ApiModules>,
+}
+
+impl Integration {
+    pub(crate) fn new() -> Self {
+        Self {
+            api: OnceLock::new(),
+        }
+    }
+
+    pub(crate) fn finish_init(&self, api: ApiModules) {
+        self.api.set(api).unwrap();
+    }
+
+    /// Create the default quit prompt.
+    ///
+    /// Some of its characteristics can be changed by setting its fields.
+    pub fn quit_prompt(&self) -> QuitPrompt {
+        QuitPrompt {
+            api: self.api.get().cloned().unwrap(),
+            border_radius: 12.0,
+            border_thickness: 6.0,
+            background_color: [0.15, 0.03, 0.1, 0.65].into(),
+            border_color: [0.8, 0.2, 0.4].into(),
+            font: Font::new_with_family(Family::Name("Ubuntu".into())),
+            width: 220,
+            height: 120,
+        }
+    }
+}
+
+/// A quit prompt.
+///
+/// When opened, pressing ENTER will quit the compositor.
+pub struct QuitPrompt {
+    api: ApiModules,
+    /// The radius of the prompt's corners.
+    pub border_radius: f32,
+    /// The thickness of the prompt border.
+    pub border_thickness: f32,
+    /// The color of the prompt background.
+    pub background_color: Color,
+    /// The color of the prompt border.
+    pub border_color: Color,
+    /// The font of the prompt.
+    pub font: Font,
+    /// The height of the prompt.
+    pub width: u32,
+    /// The width of the prompt.
+    pub height: u32,
+}
+
+impl QuitPrompt {
+    /// Show this quit prompt.
+    pub fn show(&self) {
+        let widget = Container::new(Column::new_with_children([
+            Text::new("Quit Pinnacle?")
+                .font(self.font.clone().weight(Weight::Bold))
+                .size(20.0)
+                .into(),
+            Text::new("").size(8.0).into(), // Spacing because I haven't impl'd that yet
+            Text::new("Press ENTER to confirm, or\nany other key to close this")
+                .font(self.font.clone())
+                .size(14.0)
+                .into(),
+        ]))
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .vertical_alignment(Alignment::Center)
+        .horizontal_alignment(Alignment::Center)
+        .border_radius(self.border_radius)
+        .border_thickness(self.border_thickness)
+        .border_color(self.border_color)
+        .background_color(self.background_color);
+
+        self.api
+            .snowcap
+            .layer
+            .new_widget(
+                widget,
+                self.width,
+                self.height,
+                None,
+                KeyboardInteractivity::Exclusive,
+                ExclusiveZone::Respect,
+                ZLayer::Overlay,
+            )
+            .on_key_press(|handle, key, _mods| {
+                if key == Keysym::Return {
+                    self.api.pinnacle.quit();
+                } else {
+                    handle.close();
+                }
+            });
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
             libinput
             mesa
             xwayland
+            libdisplay-info
 
             # winit on x11
             xorg.libXcursor

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -678,7 +678,7 @@ impl WlrLayerShellHandler for State {
         let output = output
             .as_ref()
             .and_then(Output::from_resource)
-            .or_else(|| self.pinnacle.space.outputs().next().cloned());
+            .or_else(|| self.pinnacle.focused_output().cloned());
 
         let Some(output) = output else {
             error!("New layer surface, but there was no output to map it on");

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,6 @@
 
 use std::{
     io::{BufRead, BufReader},
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
     time::Duration,
 };
 
@@ -27,10 +23,7 @@ use pinnacle::{
     state::State,
     util::increase_nofile_rlimit,
 };
-use smithay::reexports::{
-    calloop::{self, EventLoop},
-    rustix::process::geteuid,
-};
+use smithay::reexports::{calloop::EventLoop, rustix::process::geteuid};
 use tracing::{error, info, warn};
 use tracing_appender::rolling::Rotation;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
@@ -183,6 +176,12 @@ async fn main() -> anyhow::Result<()> {
 
     #[cfg(feature = "snowcap")]
     {
+        use smithay::reexports::calloop;
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        };
+
         info!("Starting Snowcap");
         let (ping, source) = calloop::ping::make_ping()?;
         let ready_flag = Arc::new(AtomicBool::new(false));
@@ -216,7 +215,7 @@ async fn main() -> anyhow::Result<()> {
         info!("`no-config` option was set, not spawning config");
     }
 
-    event_loop.run(None, &mut state, |state| {
+    event_loop.run(Duration::from_secs(1), &mut state, |state| {
         state.on_event_loop_cycle_completion();
     })?;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,7 +26,7 @@ use smithay::{
     input::{keyboard::XkbConfig, pointer::CursorImageStatus, Seat, SeatState},
     output::Output,
     reexports::{
-        calloop::{self, generic::Generic, Interest, LoopHandle, LoopSignal, Mode, PostAction},
+        calloop::{generic::Generic, Interest, LoopHandle, LoopSignal, Mode, PostAction},
         wayland_server::{
             backend::{ClientData, ClientId, DisconnectReason, GlobalId},
             protocol::wl_surface::WlSurface,
@@ -157,7 +157,7 @@ pub struct Pinnacle {
     pub outputs: IndexMap<Output, Option<GlobalId>>,
 
     #[cfg(feature = "snowcap")]
-    pub snowcap_shutdown_ping: Option<calloop::ping::Ping>,
+    pub snowcap_shutdown_ping: Option<smithay::reexports::calloop::ping::Ping>,
 }
 
 impl State {

--- a/wlcs_pinnacle/Cargo.toml
+++ b/wlcs_pinnacle/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 smithay = { workspace = true }
-pinnacle = { path = "..", features = [ "wlcs" ] }
-pinnacle-api = { path = "../api/rust" }
+pinnacle = { path = "..", features = ["wlcs"], default-features = false }
+pinnacle-api = { path = "../api/rust", default-features = false }
 wayland-sys = { version = "0.31.1", features = ["client", "server"] }
 wlcs = "0.1"
 


### PR DESCRIPTION
This PR adds preliminary integration for [Snowcap](https://github.com/pinnacle-comp/snowcap), the very, *very* WIP widget system for Pinnacle. Snowcap integration is gated by the `snowcap` feature, enabled by default.

Snowcap is currently, for the most part, a thin API wrapper around [Iced](https://iced.rs/). As such, the current Rust API closely mirrors their widget API.

The only currently implemented widgets are row, column, scrollable, container, and text. Using those, a goal for this PR is to implement an exit prompt and a keybind list a la Awesome.

The Lua side has not been implemented yet and will be the target of a future PR.

TODO:
- [x] Add a builtin exit prompt
- [x] Update the keybinding API to add descriptions
    - [x] Then add an API call to list all keybinds and descriptions
        - [x] Then add a builtin keybind list
- [x] Split the default Rust config into `snowcap` and non-`snowcap` variants for the feature gate
    - ~~Don't really like this tbh~~ found a decent way to do it yay
- [x] Document <sup>some of</sup> the API <sup>(i'm lazy)</sup>
- [x] Fix Rust config with Snowcap support eating up 100% of a CPU thread