### PR TITLE
Cursor enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,7 +2117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,9 @@ features = [
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"
+new_without_default = "allow"
+type_complexity = "allow"
+let_and_return = "allow"
 
 ########################################################################yo😎###########
 

--- a/api/lua/pinnacle/grpc/defs.lua
+++ b/api/lua/pinnacle/grpc/defs.lua
@@ -350,6 +350,10 @@ local pinnacle_input_v0alpha1_SetLibinputSettingRequest_TapButtonMap = {
 ---@field tap_drag_lock boolean?
 ---@field tap boolean?
 
+---@class SetXcursorRequest
+---@field theme string?
+---@field size integer?
+
 -- Process
 
 ---@class pinnacle.process.v0alpha1.SpawnRequest
@@ -768,6 +772,13 @@ defs.pinnacle = {
                     service = "pinnacle.input.v0alpha1.InputService",
                     method = "SetLibinputSetting",
                     request = "pinnacle.input.v0alpha1.SetLibinputSettingRequest",
+                    response = "google.protobuf.Empty",
+                },
+                ---@type GrpcRequestArgs
+                SetXcursor = {
+                    service = "pinnacle.input.v0alpha1.InputService",
+                    method = "SetXcursor",
+                    request = "pinnacle.input.v0alpha1.SetXcursorRequest",
                     response = "google.protobuf.Empty",
                 },
             },

--- a/api/lua/pinnacle/input.lua
+++ b/api/lua/pinnacle/input.lua
@@ -352,4 +352,28 @@ function input.set_libinput_settings(settings)
     end
 end
 
+---Sets the current xcursor theme.
+---
+---Pinnacle reads `$XCURSOR_THEME` on startup to set the theme.
+---This allows you to set it at runtime.
+---
+---@param theme string
+function input.set_xcursor_theme(theme)
+    client.unary_request(input_service.SetXcursor, {
+        theme = theme,
+    })
+end
+
+---Sets the current xcursor size.
+---
+---Pinnacle reads `$XCURSOR_SIZE` on startup to set the cursor size.
+---This allows you to set it at runtime.
+---
+---@param size integer
+function input.set_xcursor_size(size)
+    client.unary_request(input_service.SetXcursor, {
+        size = size,
+    })
+end
+
 return input

--- a/api/protocol/pinnacle/input/v0alpha1/input.proto
+++ b/api/protocol/pinnacle/input/v0alpha1/input.proto
@@ -143,6 +143,11 @@ message SetLibinputSettingRequest {
   }
 }
 
+message SetXcursorRequest {
+  optional string theme = 1;
+  optional uint32 size = 2;
+}
+
 service InputService {
   rpc SetKeybind(SetKeybindRequest) returns (stream SetKeybindResponse);
   rpc SetMousebind(SetMousebindRequest) returns (stream SetMousebindResponse);
@@ -153,4 +158,6 @@ service InputService {
   rpc SetRepeatRate(SetRepeatRateRequest) returns (google.protobuf.Empty);
 
   rpc SetLibinputSetting(SetLibinputSettingRequest) returns (google.protobuf.Empty);
+
+  rpc SetXcursor(SetXcursorRequest) returns (google.protobuf.Empty);
 }

--- a/api/rust/src/input.rs
+++ b/api/rust/src/input.rs
@@ -16,7 +16,7 @@ use pinnacle_api_defs::pinnacle::input::{
         input_service_client::InputServiceClient,
         set_libinput_setting_request::{CalibrationMatrix, Setting},
         KeybindDescriptionsRequest, SetKeybindRequest, SetLibinputSettingRequest,
-        SetMousebindRequest, SetRepeatRateRequest, SetXkbConfigRequest,
+        SetMousebindRequest, SetRepeatRateRequest, SetXcursorRequest, SetXkbConfigRequest,
     },
 };
 use tokio::sync::mpsc::UnboundedSender;
@@ -399,6 +399,46 @@ impl Input {
 
         block_on_tokio(client.set_libinput_setting(SetLibinputSettingRequest {
             setting: Some(setting),
+        }))
+        .unwrap();
+    }
+
+    /// Set the xcursor theme.
+    ///
+    /// Pinnacle reads `$XCURSOR_THEME` on startup to determine the theme.
+    /// This allows you to set it at runtime.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// input.set_xcursor_theme("Adwaita");
+    /// ```
+    pub fn set_xcursor_theme(&self, theme: impl ToString) {
+        let mut client = self.create_input_client();
+
+        block_on_tokio(client.set_xcursor(SetXcursorRequest {
+            theme: Some(theme.to_string()),
+            size: None,
+        }))
+        .unwrap();
+    }
+
+    /// Set the xcursor size.
+    ///
+    /// Pinnacle reads `$XCURSOR_SIZE` on startup to determine the cursor size.
+    /// This allows you to set it at runtime.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// input.set_xcursor_size(64);
+    /// ```
+    pub fn set_xcursor_size(&self, size: u32) {
+        let mut client = self.create_input_client();
+
+        block_on_tokio(client.set_xcursor(SetXcursorRequest {
+            theme: None,
+            size: Some(size),
         }))
         .unwrap();
     }

--- a/src/api/window.rs
+++ b/src/api/window.rs
@@ -489,7 +489,6 @@ impl window_service_server::WindowService for WindowService {
                 return;
             };
             let Some(window) = pointer_focus.window_for(state) else {
-                tracing::info!("Move grabs are currently not implemented for non-windows");
                 return;
             };
             let Some(wl_surf) = window.wl_surface() else {
@@ -498,6 +497,10 @@ impl window_service_server::WindowService for WindowService {
             let seat = state.pinnacle.seat.clone();
 
             state.move_request_server(&wl_surf, &seat, SERIAL_COUNTER.next_serial(), button);
+
+            if let Some(output) = state.pinnacle.focused_output().cloned() {
+                state.schedule_render(&output);
+            }
         })
         .await
     }
@@ -579,6 +582,10 @@ impl window_service_server::WindowService for WindowService {
                 edges.into(),
                 button,
             );
+
+            if let Some(output) = state.pinnacle.focused_output().cloned() {
+                state.schedule_render(&output);
+            }
         })
         .await
     }

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -32,11 +32,9 @@ use smithay::{
         libinput::{LibinputInputBackend, LibinputSessionInterface},
         renderer::{
             self, damage,
-            element::{
-                self, surface::render_elements_from_surface_tree, texture::TextureBuffer, Element,
-            },
+            element::{self, surface::render_elements_from_surface_tree, Element},
             gles::{GlesRenderbuffer, GlesRenderer},
-            multigpu::{gbm::GbmGlesBackend, GpuManager, MultiRenderer, MultiTexture},
+            multigpu::{gbm::GbmGlesBackend, GpuManager, MultiRenderer},
             sync::SyncPoint,
             utils::{CommitCounter, DamageSet},
             Bind, Blit, BufferType, ExportMem, ImportDma, ImportEgl, ImportMemWl, Offscreen,
@@ -57,8 +55,8 @@ use smithay::{
     reexports::{
         ash::vk::ExtPhysicalDeviceDrmFn,
         calloop::{
-            self, generic::Generic, Dispatcher, Idle, Interest, LoopHandle, PostAction,
-            RegistrationToken,
+            self, generic::Generic, timer::Timer, Dispatcher, Idle, Interest, LoopHandle,
+            PostAction, RegistrationToken,
         },
         drm::control::{connector, crtc, ModeTypeFlags},
         input::Libinput,
@@ -86,8 +84,8 @@ use crate::{
     config::ConnectorSavedState,
     output::{BlankingState, OutputMode, OutputName},
     render::{
-        pointer::PointerElement, pointer_render_elements, take_presentation_feedback,
-        OutputRenderElement, CLEAR_COLOR, CLEAR_COLOR_LOCKED,
+        pointer::pointer_render_elements, take_presentation_feedback, OutputRenderElement,
+        CLEAR_COLOR, CLEAR_COLOR_LOCKED,
     },
     state::{Pinnacle, State, SurfaceDmabufFeedback, WithState},
 };
@@ -134,9 +132,6 @@ pub struct Udev {
     allocator: Option<Box<dyn Allocator<Buffer = Dmabuf, Error = AnyError>>>,
     pub(super) gpu_manager: GpuManager<GbmGlesBackend<GlesRenderer, DrmDeviceFd>>,
     backends: HashMap<DrmNode, UdevBackendData>,
-    pointer_images: Vec<(xcursor::parser::Image, TextureBuffer<MultiTexture>)>,
-    pointer_element: PointerElement<MultiTexture>,
-    pointer_image: crate::cursor::Cursor,
 
     pub(super) upscale_filter: TextureFilter,
     pub(super) downscale_filter: TextureFilter,
@@ -225,9 +220,6 @@ impl Udev {
             gpu_manager,
             allocator: None,
             backends: HashMap::new(),
-            pointer_image: crate::cursor::Cursor::load(),
-            pointer_images: Vec::new(),
-            pointer_element: PointerElement::default(),
 
             upscale_filter: TextureFilter::Linear,
             downscale_filter: TextureFilter::Linear,
@@ -531,8 +523,10 @@ impl Udev {
 
         match &surface.render_state {
             RenderState::Idle => {
+                tracing::info!("inserting idle render");
                 let output = output.clone();
                 let token = loop_handle.insert_idle(move |state| {
+                    tracing::info!("actually rendering");
                     state
                         .backend
                         .udev_mut()
@@ -543,6 +537,7 @@ impl Udev {
             }
             RenderState::Scheduled(_) => (),
             RenderState::WaitingForVblank { dirty: _ } => {
+                tracing::info!("making dirty");
                 surface.render_state = RenderState::WaitingForVblank { dirty: true }
             }
         }
@@ -933,7 +928,7 @@ impl Udev {
                     state
                         .backend
                         .udev_mut()
-                        .on_vblank(&state.pinnacle, node, crtc, metadata);
+                        .on_vblank(&mut state.pinnacle, node, crtc, metadata);
                 }
                 DrmEvent::Error(error) => {
                     error!("{:?}", error);
@@ -1271,7 +1266,7 @@ impl Udev {
     /// Mark [`OutputPresentationFeedback`]s as presented and schedule a new render on idle.
     fn on_vblank(
         &mut self,
-        pinnacle: &Pinnacle,
+        pinnacle: &mut Pinnacle,
         dev_id: DrmNode,
         crtc: crtc::Handle,
         metadata: &mut Option<DrmEventMetadata>,
@@ -1369,6 +1364,20 @@ impl Udev {
                 );
             }
         }
+
+        // Schedule a render when the next frame of an animated cursor should be drawn.
+        if let Some(until) = pinnacle
+            .cursor_state
+            .time_until_next_animated_cursor_frame()
+        {
+            let _ = pinnacle.loop_handle.insert_source(
+                Timer::from_duration(until),
+                move |_, _, state| {
+                    state.schedule_render(&output);
+                    calloop::timer::TimeoutAction::Drop
+                },
+            );
+        }
     }
 
     /// Render to the [`RenderSurface`] associated with the given `output`.
@@ -1392,13 +1401,6 @@ impl Udev {
 
         assert!(matches!(surface.render_state, RenderState::Scheduled(_)));
 
-        // TODO get scale from the rendersurface when supporting HiDPI
-        let frame = self.pointer_image.get_image(
-            1,
-            // output.current_scale().integer_scale() as u32,
-            pinnacle.clock.now().into(),
-        );
-
         let render_node = surface.render_node;
         let primary_gpu = self.primary_gpu;
         let mut renderer = if primary_gpu == render_node {
@@ -1413,32 +1415,19 @@ impl Udev {
         let _ = renderer.upscale_filter(self.upscale_filter);
         let _ = renderer.downscale_filter(self.downscale_filter);
 
-        let pointer_images = &mut self.pointer_images;
-        let (pointer_image, hotspot) = pointer_images
-            .iter()
-            .find_map(|(image, texture)| {
-                if image == &frame {
-                    Some((texture.clone(), (frame.xhot as i32, frame.yhot as i32)))
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_else(|| {
-                let texture = TextureBuffer::from_memory(
-                    &mut renderer,
-                    &frame.pixels_rgba,
-                    Fourcc::Abgr8888,
-                    (frame.width as i32, frame.height as i32),
-                    false,
-                    1,
-                    Transform::Normal,
-                    None,
-                )
-                .expect("Failed to import cursor bitmap");
-                let hotspot = (frame.xhot as i32, frame.yhot as i32);
-                pointer_images.push((frame, texture.clone()));
-                (texture, hotspot)
-            });
+        ///////////////////////////////////////////////////////////////////////////////////////////
+
+        // draw the cursor as relevant and
+        // reset the cursor if the surface is no longer alive
+        if let CursorImageStatus::Surface(surface) = &pinnacle.cursor_state.cursor_image() {
+            if !surface.alive() {
+                pinnacle
+                    .cursor_state
+                    .set_cursor_image(CursorImageStatus::default_named());
+            }
+        }
+
+        ///////////////////////////////////////////////////////////////////////////////////////////
 
         let pointer_location = pinnacle
             .seat
@@ -1446,71 +1435,26 @@ impl Udev {
             .map(|ptr| ptr.current_location())
             .unwrap_or((0.0, 0.0).into());
 
-        // set cursor
-        self.pointer_element.set_texture(pointer_image.clone());
-
-        // draw the cursor as relevant and
-        // reset the cursor if the surface is no longer alive
-        if let CursorImageStatus::Surface(surface) = &pinnacle.cursor_status {
-            if !surface.alive() {
-                pinnacle.cursor_status = CursorImageStatus::default_named();
-            }
-        }
-
-        self.pointer_element
-            .set_status(pinnacle.cursor_status.clone());
-
-        let pending_screencopy_with_cursor =
-            output.with_state(|state| state.screencopy.as_ref().map(|sc| sc.overlay_cursor()));
-
         let mut output_render_elements = Vec::new();
 
         let should_blank = pinnacle.lock_state.is_locking()
             || (pinnacle.lock_state.is_locked()
                 && output.with_state(|state| state.lock_surface.is_none()));
 
-        // If there isn't a pending screencopy that doesn't want to overlay the cursor,
-        // render it.
-        match pending_screencopy_with_cursor {
-            Some(include_cursor) if pinnacle.lock_state.is_unlocked() => {
-                if include_cursor {
-                    // HACK: Doing `RenderFrameResult::blit_frame_result` with something on the
-                    // |     cursor plane causes the cursor to overwrite the pixels underneath it,
-                    // |     leading to a transparent hole under the cursor.
-                    // |     To circumvent that, we set the cursor to render on the primary plane instead.
-                    // |     Unfortunately that means I can't composite the cursor separately from
-                    // |     the screencopy, meaning if you have an active screencopy recording
-                    // |     without cursor overlay then the cursor will dim/flicker out/disappear.
-                    self.pointer_element
-                        .set_element_kind(element::Kind::Unspecified);
-                    let pointer_render_elements = pointer_render_elements(
-                        output,
-                        &mut renderer,
-                        &pinnacle.space,
-                        pointer_location,
-                        &mut pinnacle.cursor_status,
-                        pinnacle.dnd_icon.as_ref(),
-                        hotspot.into(),
-                        &self.pointer_element,
-                    );
-                    self.pointer_element.set_element_kind(element::Kind::Cursor);
-                    output_render_elements.extend(pointer_render_elements);
-                }
-            }
-            _ => {
-                let pointer_render_elements = pointer_render_elements(
-                    output,
-                    &mut renderer,
-                    &pinnacle.space,
-                    pointer_location,
-                    &mut pinnacle.cursor_status,
-                    pinnacle.dnd_icon.as_ref(),
-                    hotspot.into(),
-                    &self.pointer_element,
-                );
-                output_render_elements.extend(pointer_render_elements);
-            }
-        }
+        let pointer_render_elements = pointer_render_elements(
+            output,
+            &mut renderer,
+            &mut pinnacle.cursor_state,
+            &pinnacle.space,
+            pointer_location,
+            pinnacle.dnd_icon.as_ref(),
+            &pinnacle.clock,
+        );
+        output_render_elements.extend(
+            pointer_render_elements
+                .into_iter()
+                .map(OutputRenderElement::from),
+        );
 
         if should_blank {
             output.with_state_mut(|state| {
@@ -1601,7 +1545,7 @@ impl Udev {
                         scanout_feedback: &feedback.scanout_feedback,
                     }),
                 Duration::from(pinnacle.clock.now()),
-                &pinnacle.cursor_status,
+                pinnacle.cursor_state.cursor_image(),
             );
 
             let rendered = !render_frame_result.is_empty;

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -10,7 +10,7 @@ use smithay::{
             self, buffer_type,
             damage::{self, OutputDamageTracker, RenderOutputResult},
             element::{self, surface::render_elements_from_surface_tree},
-            gles::{GlesRenderbuffer, GlesRenderer, GlesTexture},
+            gles::{GlesRenderbuffer, GlesRenderer},
             Bind, Blit, BufferType, ExportMem, ImportDma, ImportEgl, ImportMemWl, Offscreen,
             TextureFilter,
         },
@@ -38,8 +38,8 @@ use tracing::{debug, error, trace, warn};
 use crate::{
     output::{BlankingState, OutputMode},
     render::{
-        pointer::PointerElement, pointer_render_elements, take_presentation_feedback, CLEAR_COLOR,
-        CLEAR_COLOR_LOCKED,
+        pointer::pointer_render_elements, take_presentation_feedback, OutputRenderElement,
+        CLEAR_COLOR, CLEAR_COLOR_LOCKED,
     },
     state::{Pinnacle, State, WithState},
 };
@@ -263,17 +263,21 @@ impl Winit {
         let full_redraw = &mut self.full_redraw;
         *full_redraw = full_redraw.saturating_sub(1);
 
-        if let CursorImageStatus::Surface(surface) = &pinnacle.cursor_status {
+        if let CursorImageStatus::Surface(surface) = pinnacle.cursor_state.cursor_image() {
             if !surface.alive() {
-                pinnacle.cursor_status = CursorImageStatus::default_named();
+                pinnacle
+                    .cursor_state
+                    .set_cursor_image(CursorImageStatus::default_named());
             }
         }
 
-        let cursor_visible = !matches!(pinnacle.cursor_status, CursorImageStatus::Surface(_));
+        let cursor_visible = !matches!(
+            pinnacle.cursor_state.cursor_image(),
+            CursorImageStatus::Surface(_)
+        );
 
-        let mut pointer_element = PointerElement::<GlesTexture>::new();
-
-        pointer_element.set_status(pinnacle.cursor_status.clone());
+        // TODO: make winit cursor disappear if not surface
+        // TODO: set winit cursor to named cursor when possible
 
         // The z-index of these is determined by `state.fixup_z_layering()`, which is called at the end
         // of every event loop cycle
@@ -300,14 +304,17 @@ impl Winit {
             let pointer_render_elements = pointer_render_elements(
                 &self.output,
                 self.backend.renderer(),
+                &mut pinnacle.cursor_state,
                 &pinnacle.space,
                 pointer_location,
-                &mut pinnacle.cursor_status,
                 pinnacle.dnd_icon.as_ref(),
-                (0, 0).into(), // Nonsurface cursors are hidden
-                &pointer_element,
+                &pinnacle.clock,
             );
-            output_render_elements.extend(pointer_render_elements);
+            output_render_elements.extend(
+                pointer_render_elements
+                    .into_iter()
+                    .map(OutputRenderElement::from),
+            );
         }
 
         let should_blank = pinnacle.lock_state.is_locking()
@@ -421,7 +428,7 @@ impl Winit {
                     &pinnacle.space,
                     None,
                     time.into(),
-                    &pinnacle.cursor_status,
+                    pinnacle.cursor_state.cursor_image(),
                 );
 
                 if has_rendered {

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -295,7 +295,7 @@ impl Winit {
                 .map(|ptr| ptr.current_location())
                 .unwrap_or((0.0, 0.0).into());
 
-            let pointer_render_elements = pointer_render_elements(
+            let (pointer_render_elements, _cursor_ids) = pointer_render_elements(
                 &self.output,
                 self.backend.renderer(),
                 &mut pinnacle.cursor_state,
@@ -303,6 +303,7 @@ impl Winit {
                 pointer_location,
                 pinnacle.dnd_icon.as_ref(),
                 &pinnacle.clock,
+                element::Kind::Cursor,
             );
             output_render_elements.extend(
                 pointer_render_elements

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -172,6 +172,8 @@ impl Winit {
             tracing::info!("EGL hardware-acceleration enabled");
         }
 
+        winit_backend.window().set_cursor_visible(false);
+
         let mut winit = Winit {
             backend: winit_backend,
             damage_tracker: OutputDamageTracker::from_output(&output),
@@ -270,14 +272,6 @@ impl Winit {
                     .set_cursor_image(CursorImageStatus::default_named());
             }
         }
-
-        let cursor_visible = !matches!(
-            pinnacle.cursor_state.cursor_image(),
-            CursorImageStatus::Surface(_)
-        );
-
-        // TODO: make winit cursor disappear if not surface
-        // TODO: set winit cursor to named cursor when possible
 
         // The z-index of these is determined by `state.fixup_z_layering()`, which is called at the end
         // of every event loop cycle
@@ -417,8 +411,6 @@ impl Winit {
                         }
                     }
                 }
-
-                self.backend.window().set_cursor_visible(cursor_visible);
 
                 let time = pinnacle.clock.now();
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -84,7 +84,9 @@ impl CursorState {
                 // TODO: scale
                 let buffer = MemoryRenderBuffer::from_slice(
                     &image.pixels_rgba,
-                    Fourcc::Abgr8888,
+                    // Don't make Abgr, then the format doesn't match the
+                    // cursor bo and this doesn't get put on the cursor plane
+                    Fourcc::Argb8888,
                     (image.width as i32, image.height as i32),
                     scale,
                     Transform::Normal,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -10,11 +10,15 @@ mod xwayland;
 use std::{collections::HashMap, mem, os::fd::OwnedFd, sync::Arc};
 
 use smithay::{
-    backend::renderer::utils::{self, with_renderer_surface_state},
-    delegate_compositor, delegate_data_control, delegate_data_device, delegate_fractional_scale,
-    delegate_layer_shell, delegate_output, delegate_pointer_constraints, delegate_presentation,
-    delegate_primary_selection, delegate_relative_pointer, delegate_seat,
-    delegate_security_context, delegate_shm, delegate_viewporter, delegate_xwayland_shell,
+    backend::{
+        input::TabletToolDescriptor,
+        renderer::utils::{self, with_renderer_surface_state},
+    },
+    delegate_compositor, delegate_cursor_shape, delegate_data_control, delegate_data_device,
+    delegate_fractional_scale, delegate_layer_shell, delegate_output, delegate_pointer_constraints,
+    delegate_presentation, delegate_primary_selection, delegate_relative_pointer, delegate_seat,
+    delegate_security_context, delegate_shm, delegate_tablet_manager, delegate_viewporter,
+    delegate_xwayland_shell,
     desktop::{
         self, find_popup_root_surface, get_popup_toplevel_coords, layer_map_for_output, PopupKind,
         PopupManager, WindowSurfaceType,
@@ -62,13 +66,11 @@ use smithay::{
             SelectionHandler, SelectionSource, SelectionTarget,
         },
         shell::{
-            wlr_layer::{
-                self, Layer, LayerSurfaceCachedState, LayerSurfaceData, WlrLayerShellHandler,
-                WlrLayerShellState,
-            },
+            wlr_layer::{self, Layer, LayerSurfaceData, WlrLayerShellHandler, WlrLayerShellState},
             xdg::{PopupSurface, XdgPopupSurfaceData, XdgToplevelSurfaceData},
         },
         shm::{ShmHandler, ShmState},
+        tablet_manager::TabletSeatHandler,
         xwayland_shell::{XWaylandShellHandler, XWaylandShellState},
     },
     xwayland::XWaylandClientData,
@@ -541,7 +543,7 @@ impl SeatHandler for State {
     }
 
     fn cursor_image(&mut self, _seat: &Seat<Self>, image: CursorImageStatus) {
-        self.pinnacle.cursor_status = image;
+        self.pinnacle.cursor_state.set_cursor_image(image);
     }
 
     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&Self::KeyboardFocus>) {
@@ -897,6 +899,17 @@ impl OutputPowerManagementHandler for State {
     }
 }
 delegate_output_power_management!(State);
+
+impl TabletSeatHandler for State {
+    fn tablet_tool_image(&mut self, tool: &TabletToolDescriptor, image: CursorImageStatus) {
+        // TODO:
+        let _ = tool;
+        let _ = image;
+    }
+}
+delegate_tablet_manager!(State);
+
+delegate_cursor_shape!(State);
 
 impl Pinnacle {
     fn position_popup(&self, popup: &PopupSurface) {

--- a/src/handlers/xwayland.rs
+++ b/src/handlers/xwayland.rs
@@ -511,7 +511,7 @@ impl Pinnacle {
                         .get_xcursor_images(CursorIcon::Default)
                         .unwrap();
                     let image =
-                        cursor.image(Duration::ZERO, state.pinnacle.cursor_state.cursor_size());
+                        cursor.image(Duration::ZERO, state.pinnacle.cursor_state.cursor_size(1)); // TODO: scale
                     wm.set_cursor(
                         &image.pixels_rgba,
                         Size::from((image.width as u16, image.height as u16)),

--- a/src/handlers/xwayland.rs
+++ b/src/handlers/xwayland.rs
@@ -4,6 +4,7 @@ use std::{process::Stdio, time::Duration};
 
 use smithay::{
     desktop::Window,
+    input::pointer::CursorIcon,
     utils::{Logical, Point, Rectangle, Size, SERIAL_COUNTER},
     wayland::selection::{
         data_device::{
@@ -24,7 +25,6 @@ use smithay::{
 use tracing::{debug, error, trace, warn};
 
 use crate::{
-    cursor::Cursor,
     focus::keyboard::KeyboardFocusTarget,
     state::{Pinnacle, State, WithState},
     window::{window_state::FloatingOrTiled, WindowElement},
@@ -505,8 +505,13 @@ impl Pinnacle {
                     )
                     .expect("Failed to attach x11wm");
 
-                    let cursor = Cursor::load();
-                    let image = cursor.get_image(1, Duration::ZERO);
+                    let cursor = state
+                        .pinnacle
+                        .cursor_state
+                        .get_xcursor_images(CursorIcon::Default)
+                        .unwrap();
+                    let image =
+                        cursor.image(Duration::ZERO, state.pinnacle.cursor_state.cursor_size());
                     wm.set_cursor(
                         &image.pixels_rgba,
                         Size::from((image.width as u16, image.height as u16)),

--- a/src/input.rs
+++ b/src/input.rs
@@ -438,7 +438,6 @@ impl State {
 
         if self.pinnacle.lock_state.is_unlocked() {
             // Focus the topmost exclusive layer, if any
-            let mut exclusive_layers_exist = false;
             for layer in self.pinnacle.layer_shell_state.layer_surfaces().rev() {
                 let data = compositor::with_states(layer.wl_surface(), |states| {
                     *states.cached_state.current::<LayerSurfaceCachedState>()
@@ -456,7 +455,6 @@ impl State {
                     });
 
                     if let Some(layer_surface) = layer_surface {
-                        exclusive_layers_exist = true;
                         keyboard.set_focus(
                             self,
                             Some(KeyboardFocusTarget::LayerSurface(layer_surface)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     event_loop.run(Duration::from_secs(1), &mut state, |state| {
+        tracing::info!("after idles");
         state.on_event_loop_cycle_completion();
     })?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,6 @@ async fn main() -> anyhow::Result<()> {
     }
 
     event_loop.run(Duration::from_secs(1), &mut state, |state| {
-        tracing::info!("after idles");
         state.on_event_loop_cycle_completion();
     })?;
 

--- a/src/render/pointer.rs
+++ b/src/render/pointer.rs
@@ -1,99 +1,123 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use std::{rc::Rc, sync::Mutex};
+
 use smithay::{
     backend::renderer::{
         element::{
             self,
-            surface::{self, WaylandSurfaceRenderElement},
-            texture::{TextureBuffer, TextureRenderElement},
+            memory::MemoryRenderBufferRenderElement,
+            surface::{render_elements_from_surface_tree, WaylandSurfaceRenderElement},
             AsRenderElements,
         },
-        ImportAll, Renderer, Texture,
+        ImportAll, ImportMem,
     },
-    input::pointer::CursorImageStatus,
+    desktop::Space,
+    input::pointer::CursorImageAttributes,
+    output::Output,
+    reexports::wayland_server::protocol::wl_surface::WlSurface,
     render_elements,
-    utils::{Physical, Point, Scale},
+    utils::{Clock, Logical, Monotonic, Point, Scale},
+    wayland::compositor,
+};
+
+use crate::{
+    cursor::{CursorState, XCursor},
+    window::WindowElement,
 };
 
 use super::PRenderer;
 
-pub struct PointerElement<T: Texture> {
-    texture: Option<TextureBuffer<T>>,
-    status: CursorImageStatus,
-    kind: element::Kind,
-}
-
-impl<T: Texture> Default for PointerElement<T> {
-    fn default() -> Self {
-        Self {
-            texture: Default::default(),
-            status: CursorImageStatus::default_named(),
-            kind: element::Kind::Cursor,
-        }
-    }
-}
-
-impl<T: Texture> PointerElement<T> {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    pub fn set_status(&mut self, status: CursorImageStatus) {
-        self.status = status;
-    }
-
-    pub fn set_texture(&mut self, texture: TextureBuffer<T>) {
-        self.texture = Some(texture);
-    }
-
-    pub fn set_element_kind(&mut self, kind: element::Kind) {
-        self.kind = kind;
-    }
+pub enum PointerElement {
+    Hidden,
+    Named { cursor: Rc<XCursor>, size: u32 },
+    Surface { surface: WlSurface },
 }
 
 render_elements! {
     #[derive(Debug)]
-    pub PointerRenderElement<R> where R: ImportAll;
-    Surface=WaylandSurfaceRenderElement<R>,
-    Texture=TextureRenderElement<<R as Renderer>::TextureId>,
+    pub PointerRenderElement<R> where R: ImportAll + ImportMem;
+    Surface = WaylandSurfaceRenderElement<R>,
+    Memory = MemoryRenderBufferRenderElement<R>,
 }
 
-impl<R: PRenderer> AsRenderElements<R> for PointerElement<R::TextureId> {
-    type RenderElement = PointerRenderElement<R>;
+pub fn pointer_render_elements<R: PRenderer>(
+    output: &Output,
+    renderer: &mut R,
+    cursor_state: &mut CursorState,
+    space: &Space<WindowElement>,
+    pointer_location: Point<f64, Logical>,
+    dnd_icon: Option<&WlSurface>,
+    clock: &Clock<Monotonic>,
+) -> Vec<PointerRenderElement<R>> {
+    let mut pointer_render_elements = Vec::new();
 
-    fn render_elements<C: From<Self::RenderElement>>(
-        &self,
-        renderer: &mut R,
-        location: Point<i32, Physical>,
-        scale: Scale<f64>,
-        alpha: f32,
-    ) -> Vec<C> {
-        match &self.status {
-            CursorImageStatus::Hidden => vec![],
-            CursorImageStatus::Named(_) => {
-                if let Some(texture) = self.texture.as_ref() {
-                    vec![PointerRenderElement::<R>::from(
-                        TextureRenderElement::from_texture_buffer(
-                            location.to_f64(),
-                            texture,
-                            None,
-                            None,
-                            None,
-                            self.kind,
-                        ),
-                    )
-                    .into()]
-                } else {
-                    vec![]
-                }
+    let Some(output_geometry) = space.output_geometry(output) else {
+        return pointer_render_elements;
+    };
+
+    let scale = Scale::from(output.current_scale().fractional_scale());
+
+    let pointer_elem = cursor_state.pointer_element();
+
+    if output_geometry.to_f64().contains(pointer_location) {
+        let cursor_pos = pointer_location - output_geometry.loc.to_f64();
+
+        let mut elements = match &pointer_elem {
+            PointerElement::Hidden => vec![],
+            PointerElement::Named { cursor, size } => {
+                let image = cursor.image(clock.now().into(), *size);
+                let hotspot = (image.xhot as i32, image.yhot as i32);
+                let buffer = cursor_state.buffer_for_image(image);
+                let elem = MemoryRenderBufferRenderElement::from_buffer(
+                    renderer,
+                    (cursor_pos - Point::from(hotspot).to_f64()).to_physical_precise_round(scale),
+                    &buffer,
+                    None,
+                    None,
+                    None,
+                    element::Kind::Cursor,
+                );
+
+                elem.map(|elem| vec![PointerRenderElement::Memory(elem)])
+                    .unwrap_or_default()
             }
-            CursorImageStatus::Surface(surface) => {
-                let elements: Vec<PointerRenderElement<R>> =
-                    surface::render_elements_from_surface_tree(
-                        renderer, surface, location, scale, alpha, self.kind,
-                    );
-                elements.into_iter().map(C::from).collect()
+            PointerElement::Surface { surface } => {
+                let hotspot = compositor::with_states(surface, |states| {
+                    states
+                        .data_map
+                        .get::<Mutex<CursorImageAttributes>>()
+                        .expect("surface data map had no CursorImageAttributes")
+                        .lock()
+                        .expect("failed to lock mutex")
+                        .hotspot
+                });
+
+                let elems = render_elements_from_surface_tree(
+                    renderer,
+                    surface,
+                    (cursor_pos - hotspot.to_f64()).to_physical_precise_round(scale),
+                    scale,
+                    1.0,
+                    element::Kind::Cursor,
+                );
+
+                elems
             }
+        };
+
+        if let Some(dnd_icon) = dnd_icon {
+            elements.extend(AsRenderElements::render_elements(
+                &smithay::desktop::space::SurfaceTree::from_surface(dnd_icon),
+                renderer,
+                cursor_pos.to_physical_precise_round(scale),
+                scale,
+                1.0,
+            ));
         }
+
+        pointer_render_elements = elements;
     }
+
+    pointer_render_elements
 }

--- a/src/render/pointer.rs
+++ b/src/render/pointer.rs
@@ -57,6 +57,7 @@ pub fn pointer_render_elements<R: PRenderer>(
     };
 
     let scale = Scale::from(output.current_scale().fractional_scale());
+    let integer_scale = output.current_scale().integer_scale();
 
     let pointer_elem = cursor_state.pointer_element();
 
@@ -66,12 +67,13 @@ pub fn pointer_render_elements<R: PRenderer>(
         let mut elements = match &pointer_elem {
             PointerElement::Hidden => vec![],
             PointerElement::Named { cursor, size } => {
-                let image = cursor.image(clock.now().into(), *size);
+                let image = cursor.image(clock.now().into(), *size * integer_scale as u32);
                 let hotspot = (image.xhot as i32, image.yhot as i32);
-                let buffer = cursor_state.buffer_for_image(image);
+                let buffer = cursor_state.buffer_for_image(image, integer_scale);
                 let elem = MemoryRenderBufferRenderElement::from_buffer(
                     renderer,
-                    (cursor_pos - Point::from(hotspot).to_f64()).to_physical_precise_round(scale),
+                    (cursor_pos - Point::from(hotspot).downscale(integer_scale).to_f64())
+                        .to_physical_precise_round(scale),
                     &buffer,
                     None,
                     None,


### PR DESCRIPTION
This PR contains enhancements for cursor rendering, including `cursor-shape-v1` support and a better xcursor implementation. As a result, animated cursors now work properly.

TODO:
- [x] Add API calls for setting xcursor theme and size
- [x] Implement cursor scaling
- [x] Change the cursor to a grab one when Super + left click moving a window
- [x] Change the cursor to a resize one when Super + right click resizing
- [x] Hide the winit cursor when necessary
- [x] Fix screencopies having the cursor overwrite transparency
- [x] Clean up all the print debugging everywhere