### PR TITLE
Improve window state handling

### DIFF
--- a/api/lua/pinnacle/grpc/defs.lua
+++ b/api/lua/pinnacle/grpc/defs.lua
@@ -180,6 +180,7 @@ local pinnacle_output_v0alpha1_Transform = {
 ---@field floating boolean?
 ---@field fullscreen_or_maximized pinnacle.window.v0alpha1.FullscreenOrMaximized?
 ---@field tag_ids integer[]?
+---@field state pinnacle.window.v0alpha1.WindowState?
 
 ---@enum pinnacle.window.v0alpha1.FullscreenOrMaximized
 local pinnacle_window_v0alpha1_FullscreenOrMaximized = {
@@ -200,6 +201,15 @@ local pinnacle_window_v0alpha1_FullscreenOrMaximized = {
 ---@field titles string[]?
 ---@field tags integer[]?
 
+---@enum pinnacle.window.v0alpha1.WindowState
+local pinnacle_window_v0alpha1_WindowState = {
+    WINDOW_STATE_UNSPECIFIED = 0,
+    WINDOW_STATE_TILED = 1,
+    WINDOW_STATE_FLOATING = 2,
+    WINDOW_STATE_FULLSCREEN = 3,
+    WINDOW_STATE_MAXIMIZED = 4,
+}
+
 ---@class pinnacle.window.v0alpha1.WindowRule
 ---@field output string?
 ---@field tags integer[]?
@@ -210,6 +220,7 @@ local pinnacle_window_v0alpha1_FullscreenOrMaximized = {
 ---@field width integer?
 ---@field height integer?
 ---@field ssd boolean?
+---@field state pinnacle.window.v0alpha1.WindowState?
 
 -- Tag
 
@@ -560,6 +571,7 @@ defs.pinnacle = {
             FullscreenOrMaximized = util.bijective_table(
                 pinnacle_window_v0alpha1_FullscreenOrMaximized
             ),
+            WindowState = util.bijective_table(pinnacle_window_v0alpha1_WindowState),
             WindowService = {
                 ---@type GrpcRequestArgs
                 Close = {

--- a/api/protocol/pinnacle/window/v0alpha1/window.proto
+++ b/api/protocol/pinnacle/window/v0alpha1/window.proto
@@ -74,9 +74,10 @@ message GetPropertiesResponse {
   optional string class = 2;
   optional string title = 3;
   optional bool focused = 4;
-  optional bool floating = 5;
-  optional FullscreenOrMaximized fullscreen_or_maximized = 6;
+  optional bool floating = 5 [deprecated = true];
+  optional FullscreenOrMaximized fullscreen_or_maximized = 6 [deprecated = true];
   repeated uint32 tag_ids = 7;
+  optional WindowState state = 8;
 }
 
 enum FullscreenOrMaximized {
@@ -99,12 +100,25 @@ message WindowRuleCondition {
   repeated uint32 tags = 5;
 }
 
+enum WindowState {
+  WINDOW_STATE_UNSPECIFIED = 0;
+  WINDOW_STATE_TILED = 1;
+  WINDOW_STATE_FLOATING = 2;
+  WINDOW_STATE_FULLSCREEN = 3;
+  WINDOW_STATE_MAXIMIZED = 4;
+}
+
 message WindowRule {
   optional string output = 1;
   repeated uint32 tags = 2;
+
+  // DEPRECATED
+  // TODO: remove in 0.1/0.2
   // `true` for floating, `false` for tiled
   optional bool floating = 3;
 
+  // DEPRECATED
+  // TODO: remove in 0.1/0.2
   optional FullscreenOrMaximized fullscreen_or_maximized = 4;
 
   optional int32 x = 5;
@@ -113,6 +127,8 @@ message WindowRule {
   optional int32 height = 8;
   // true to force ssd, false to force csd, null to not force anything
   optional bool ssd = 9;
+
+  optional WindowState state = 10;
 }
 
 service WindowService {

--- a/api/rust/src/window/rules.rs
+++ b/api/rust/src/window/rules.rs
@@ -412,7 +412,7 @@ impl WindowRule {
         self
     }
 
-    /// This rule will force windows to open either floating or not.
+    /// This rule will force windows to open either floating if true or tiled if false.
     ///
     /// # Examples
     ///
@@ -426,7 +426,10 @@ impl WindowRule {
     /// let rule = WindowRule::new().floating(false);
     /// ```
     pub fn floating(mut self, floating: bool) -> Self {
-        self.0.floating = Some(floating);
+        self.0.set_state(match floating {
+            true => window::v0alpha1::WindowState::Floating,
+            false => window::v0alpha1::WindowState::Tiled,
+        });
         self
     }
 
@@ -447,11 +450,42 @@ impl WindowRule {
     /// // Force the window to open not fullscreen nor maximized
     /// let rule = WindowRule::new().fullscreen_or_maximized(FullscreenOrMaximized::Neither);
     /// ```
+    #[deprecated = "use the `fullscreen` or `maximized` methods instead"]
     pub fn fullscreen_or_maximized(
         mut self,
         fullscreen_or_maximized: FullscreenOrMaximized,
     ) -> Self {
         self.0.fullscreen_or_maximized = Some(fullscreen_or_maximized as i32);
+        self
+    }
+
+    /// This rule will force windows to open fullscreen.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pinnacle_api::window::rules::WindowRule;
+    ///
+    /// // Force the window to open fullscreen
+    /// let rule = WindowRule::new().fullscreen();
+    /// ```
+    pub fn fullscreen(mut self) -> Self {
+        self.0.set_state(window::v0alpha1::WindowState::Fullscreen);
+        self
+    }
+
+    /// This rule will force windows to open maximized.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pinnacle_api::window::rules::WindowRule;
+    ///
+    /// // Force the window to open fullscreen
+    /// let rule = WindowRule::new().maximized();
+    /// ```
+    pub fn maximized(mut self) -> Self {
+        self.0.set_state(window::v0alpha1::WindowState::Maximized);
         self
     }
 

--- a/src/grab/move_grab.rs
+++ b/src/grab/move_grab.rs
@@ -70,9 +70,9 @@ impl PointerGrab<State> for MoveSurfaceGrab {
             }
         }
 
-        let can_move = self.window.with_state(|state| {
-            state.floating_or_tiled.is_floating() && state.fullscreen_or_maximized.is_neither()
-        });
+        let can_move = self
+            .window
+            .with_state(|state| state.window_state.is_floating());
 
         if can_move {
             let delta = event.location - self.start_data.location;
@@ -132,7 +132,7 @@ impl PointerGrab<State> for MoveSurfaceGrab {
                 }
 
                 if window_under.with_state(|state| {
-                    state.floating_or_tiled.is_floating() || state.target_loc.is_some()
+                    state.window_state.is_floating() || state.target_loc.is_some()
                 }) {
                     return;
                 }

--- a/src/grab/resize_grab.rs
+++ b/src/grab/resize_grab.rs
@@ -22,7 +22,7 @@ use smithay::{
 
 use crate::{
     state::{Pinnacle, State, WithState},
-    window::{window_state::FloatingOrTiled, WindowElement},
+    window::WindowElement,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -451,19 +451,8 @@ impl Pinnacle {
             window_loc.y = new_y;
         }
 
-        let size = self
-            .space
-            .element_geometry(&window)
-            .expect("called element_geometry on unmapped window")
-            .size;
-
         window.with_state_mut(|state| {
-            if state.floating_or_tiled.is_floating() {
-                state.floating_or_tiled = FloatingOrTiled::Floating {
-                    loc: window_loc,
-                    size,
-                };
-            }
+            state.floating_loc = Some(window_loc);
         });
 
         if new_loc.0.is_some() || new_loc.1.is_some() {

--- a/src/grab/resize_grab.rs
+++ b/src/grab/resize_grab.rs
@@ -404,6 +404,10 @@ impl Pinnacle {
             return;
         };
 
+        if window.with_state(|state| !state.window_state.is_floating()) {
+            return;
+        }
+
         // FIXME: i32 -> f64
         let Some(mut window_loc) = self.space.element_location(&window).map(|loc| loc.to_f64())
         else {
@@ -437,10 +441,6 @@ impl Pinnacle {
                 },
             )
         });
-
-        if window.with_state(|state| state.floating_or_tiled.is_tiled()) {
-            return;
-        }
 
         let Some(new_loc) = new_loc else { return };
 
@@ -492,8 +492,7 @@ impl State {
                 return;
             };
 
-            // TODO: check for fullscreen/maximized (probably shouldn't matter)
-            if window.with_state(|state| state.floating_or_tiled.is_tiled()) {
+            if window.with_state(|state| !state.window_state.is_floating()) {
                 return;
             }
 
@@ -547,7 +546,7 @@ impl State {
             return;
         };
 
-        if window.with_state(|state| state.floating_or_tiled.is_tiled()) {
+        if window.with_state(|state| !state.window_state.is_floating()) {
             return;
         }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -73,7 +73,7 @@ use smithay::{
         },
         shell::{
             wlr_layer::{self, Layer, LayerSurfaceData, WlrLayerShellHandler, WlrLayerShellState},
-            xdg::{PopupSurface, XdgPopupSurfaceData, XdgToplevelSurfaceData},
+            xdg::{PopupSurface, SurfaceCachedState, XdgPopupSurfaceData, XdgToplevelSurfaceData},
         },
         shm::{ShmHandler, ShmState},
         tablet_manager::TabletSeatHandler,
@@ -103,6 +103,7 @@ use crate::{
         screencopy::{Screencopy, ScreencopyHandler},
     },
     state::{ClientState, Pinnacle, State, WithState},
+    window::window_state::FloatingOrTiled,
 };
 
 impl BufferHandler for State {
@@ -213,6 +214,39 @@ impl CompositorHandler for State {
                         self.capture_snapshots_on_output(output, []);
                     }
 
+                    unmapped_window.with_state_mut(|state| {
+                        if state.floating_size.is_none() {
+                            state.floating_size = Some(unmapped_window.geometry().size);
+                        }
+                    });
+
+                    // Float windows if necessary
+                    if let Some(toplevel) = unmapped_window.toplevel() {
+                        let has_parent = toplevel.parent().is_some();
+                        let (min_size, max_size) =
+                            compositor::with_states(toplevel.wl_surface(), |states| {
+                                let mut guard = states.cached_state.get::<SurfaceCachedState>();
+                                let state = guard.current();
+                                (state.min_size, state.max_size)
+                            });
+
+                        let requests_constrained_size = min_size.w > 0
+                            && min_size.h > 0
+                            && (min_size.w == max_size.w || min_size.h == max_size.h);
+
+                        let should_float = has_parent || requests_constrained_size;
+
+                        if should_float {
+                            unmapped_window.with_state_mut(|state| {
+                                state.floating_or_tiled = FloatingOrTiled::Floating
+                            });
+                        }
+                    }
+
+                    if unmapped_window.with_state(|state| state.floating_or_tiled.is_floating()) {
+                        self.pinnacle.set_window_floating(&unmapped_window, true);
+                    }
+
                     self.pinnacle
                         .unmapped_windows
                         .retain(|win| win != unmapped_window);
@@ -224,8 +258,27 @@ impl CompositorHandler for State {
                         if unmapped_window.is_on_active_tag() {
                             self.update_keyboard_focus(&focused_output);
 
-                            self.pinnacle.begin_layout_transaction(&focused_output);
-                            self.pinnacle.request_layout(&focused_output);
+                            if unmapped_window.with_state(|state| {
+                                state.floating_or_tiled.is_floating()
+                                    && state.fullscreen_or_maximized.is_neither()
+                            }) {
+                                // TODO: make this sync with commit
+                                let loc = unmapped_window
+                                    .with_state(|state| state.floating_loc)
+                                    .unwrap();
+                                self.pinnacle.space.map_element(
+                                    unmapped_window.clone(),
+                                    loc.to_i32_round(),
+                                    true,
+                                );
+                                unmapped_window
+                                    .toplevel()
+                                    .expect("unreachable")
+                                    .send_pending_configure();
+                            } else {
+                                self.pinnacle.begin_layout_transaction(&focused_output);
+                                self.pinnacle.request_layout(&focused_output);
+                            }
 
                             // It seems wlcs needs immediate frame sends for client tests to work
                             #[cfg(feature = "testing")]
@@ -242,6 +295,17 @@ impl CompositorHandler for State {
                         unmapped_window.place_on_output(&output);
                     }
                     self.pinnacle.apply_window_rules(&unmapped_window);
+                    if unmapped_window.with_state(|state| {
+                        state.floating_or_tiled.is_floating()
+                            && state.fullscreen_or_maximized.is_neither()
+                    }) {
+                        if let Some(size) = unmapped_window.with_state(|state| state.floating_size)
+                        {
+                            if let Some(toplevel) = unmapped_window.toplevel() {
+                                toplevel.with_pending_state(|state| state.size = Some(size));
+                            }
+                        }
+                    }
                     // Still unmapped
                     unmapped_window.on_commit();
                     self.pinnacle.ensure_initial_configure(surface);

--- a/src/handlers/foreign_toplevel.rs
+++ b/src/handlers/foreign_toplevel.rs
@@ -60,7 +60,7 @@ impl ForeignToplevelHandler for State {
             return;
         };
 
-        self.set_window_fullscreen(&window, true);
+        self.set_window_fullscreen_and_layout(&window, true);
     }
 
     fn unset_fullscreen(&mut self, wl_surface: WlSurface) {
@@ -68,7 +68,7 @@ impl ForeignToplevelHandler for State {
             return;
         };
 
-        self.set_window_fullscreen(&window, false);
+        self.set_window_fullscreen_and_layout(&window, false);
     }
 
     fn set_maximized(&mut self, wl_surface: WlSurface) {
@@ -76,7 +76,7 @@ impl ForeignToplevelHandler for State {
             return;
         };
 
-        self.set_window_maximized(&window, true);
+        self.set_window_maximized_and_layout(&window, true);
     }
 
     fn unset_maximized(&mut self, wl_surface: WlSurface) {
@@ -84,7 +84,7 @@ impl ForeignToplevelHandler for State {
             return;
         };
 
-        self.set_window_maximized(&window, false);
+        self.set_window_maximized_and_layout(&window, false);
     }
 
     fn set_minimized(&mut self, wl_surface: WlSurface) {

--- a/src/handlers/foreign_toplevel.rs
+++ b/src/handlers/foreign_toplevel.rs
@@ -60,7 +60,8 @@ impl ForeignToplevelHandler for State {
             return;
         };
 
-        self.set_window_fullscreen_and_layout(&window, true);
+        window.with_state_mut(|state| state.window_state.set_fullscreen(true));
+        self.update_window_state_and_layout(&window);
     }
 
     fn unset_fullscreen(&mut self, wl_surface: WlSurface) {
@@ -68,7 +69,8 @@ impl ForeignToplevelHandler for State {
             return;
         };
 
-        self.set_window_fullscreen_and_layout(&window, false);
+        window.with_state_mut(|state| state.window_state.set_fullscreen(false));
+        self.update_window_state_and_layout(&window);
     }
 
     fn set_maximized(&mut self, wl_surface: WlSurface) {
@@ -76,7 +78,8 @@ impl ForeignToplevelHandler for State {
             return;
         };
 
-        self.set_window_maximized_and_layout(&window, true);
+        window.with_state_mut(|state| state.window_state.set_maximized(true));
+        self.update_window_state_and_layout(&window);
     }
 
     fn unset_maximized(&mut self, wl_surface: WlSurface) {
@@ -84,9 +87,11 @@ impl ForeignToplevelHandler for State {
             return;
         };
 
-        self.set_window_maximized_and_layout(&window, false);
+        window.with_state_mut(|state| state.window_state.set_maximized(false));
+        self.update_window_state_and_layout(&window);
     }
 
+    // TODO:
     fn set_minimized(&mut self, wl_surface: WlSurface) {
         let Some(window) = self.pinnacle.window_for_surface(&wl_surface) else {
             return;
@@ -102,6 +107,7 @@ impl ForeignToplevelHandler for State {
         self.schedule_render(&output);
     }
 
+    // TODO:
     fn unset_minimized(&mut self, wl_surface: WlSurface) {
         let Some(window) = self.pinnacle.window_for_surface(&wl_surface) else {
             return;

--- a/src/handlers/window.rs
+++ b/src/handlers/window.rs
@@ -1,22 +1,13 @@
-use crate::{
-    state::{State, WithState},
-    window::WindowElement,
-};
+use crate::{state::State, window::WindowElement};
 
 impl State {
-    pub fn set_window_maximized(&mut self, window: &WindowElement, maximized: bool) {
+    pub fn set_window_maximized_and_layout(&mut self, window: &WindowElement, maximized: bool) {
         let output = window.output(&self.pinnacle);
         if let Some(output) = output.as_ref() {
             self.capture_snapshots_on_output(output, [window.clone()]);
         }
 
-        if maximized {
-            if !window.with_state(|state| state.fullscreen_or_maximized.is_maximized()) {
-                window.toggle_maximized();
-            }
-        } else if window.with_state(|state| state.fullscreen_or_maximized.is_maximized()) {
-            window.toggle_maximized();
-        }
+        self.pinnacle.set_window_maximized(window, maximized);
 
         if let Some(output) = output {
             self.pinnacle.begin_layout_transaction(&output);
@@ -26,19 +17,13 @@ impl State {
         }
     }
 
-    pub fn set_window_fullscreen(&mut self, window: &WindowElement, fullscreen: bool) {
+    pub fn set_window_fullscreen_and_layout(&mut self, window: &WindowElement, fullscreen: bool) {
         let output = window.output(&self.pinnacle);
         if let Some(output) = output.as_ref() {
             self.capture_snapshots_on_output(output, [window.clone()]);
         }
 
-        if fullscreen {
-            if !window.with_state(|state| state.fullscreen_or_maximized.is_fullscreen()) {
-                window.toggle_fullscreen();
-            }
-        } else if window.with_state(|state| state.fullscreen_or_maximized.is_fullscreen()) {
-            window.toggle_fullscreen();
-        }
+        self.pinnacle.set_window_fullscreen(window, fullscreen);
 
         if let Some(output) = window.output(&self.pinnacle) {
             self.pinnacle.begin_layout_transaction(&output);

--- a/src/handlers/window.rs
+++ b/src/handlers/window.rs
@@ -1,34 +1,20 @@
 use crate::{state::State, window::WindowElement};
 
 impl State {
-    pub fn set_window_maximized_and_layout(&mut self, window: &WindowElement, maximized: bool) {
+    pub fn update_window_state_and_layout(&mut self, window: &WindowElement) {
         let output = window.output(&self.pinnacle);
         if let Some(output) = output.as_ref() {
             self.capture_snapshots_on_output(output, [window.clone()]);
         }
 
-        self.pinnacle.set_window_maximized(window, maximized);
-
-        if let Some(output) = output {
-            self.pinnacle.begin_layout_transaction(&output);
-            self.pinnacle.request_layout(&output);
-
-            self.schedule_render(&output);
-        }
-    }
-
-    pub fn set_window_fullscreen_and_layout(&mut self, window: &WindowElement, fullscreen: bool) {
-        let output = window.output(&self.pinnacle);
-        if let Some(output) = output.as_ref() {
-            self.capture_snapshots_on_output(output, [window.clone()]);
-        }
-
-        self.pinnacle.set_window_fullscreen(window, fullscreen);
+        self.pinnacle.update_window_state(window);
 
         if let Some(output) = window.output(&self.pinnacle) {
             self.pinnacle.begin_layout_transaction(&output);
             self.pinnacle.request_layout(&output);
+        }
 
+        for output in self.pinnacle.space.outputs_for_element(window) {
             self.schedule_render(&output);
         }
     }

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -231,7 +231,8 @@ impl XdgShellHandler for State {
                 return;
             };
 
-            self.set_window_fullscreen_and_layout(&window, true);
+            window.with_state_mut(|state| state.window_state.set_fullscreen(true));
+            self.update_window_state_and_layout(&window);
         }
 
         surface.send_configure();
@@ -246,7 +247,8 @@ impl XdgShellHandler for State {
             return;
         };
 
-        self.set_window_fullscreen_and_layout(&window, false);
+        window.with_state_mut(|state| state.window_state.set_fullscreen(false));
+        self.update_window_state_and_layout(&window);
     }
 
     fn maximize_request(&mut self, surface: ToplevelSurface) {
@@ -254,7 +256,8 @@ impl XdgShellHandler for State {
             return;
         };
 
-        self.set_window_maximized_and_layout(&window, true);
+        window.with_state_mut(|state| state.window_state.set_maximized(true));
+        self.update_window_state_and_layout(&window);
     }
 
     fn unmaximize_request(&mut self, surface: ToplevelSurface) {
@@ -262,7 +265,8 @@ impl XdgShellHandler for State {
             return;
         };
 
-        self.set_window_maximized_and_layout(&window, false);
+        window.with_state_mut(|state| state.window_state.set_maximized(false));
+        self.update_window_state_and_layout(&window);
     }
 
     fn minimize_request(&mut self, _surface: ToplevelSurface) {

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -231,7 +231,7 @@ impl XdgShellHandler for State {
                 return;
             };
 
-            self.set_window_fullscreen(&window, true);
+            self.set_window_fullscreen_and_layout(&window, true);
         }
 
         surface.send_configure();
@@ -246,7 +246,7 @@ impl XdgShellHandler for State {
             return;
         };
 
-        self.set_window_fullscreen(&window, false);
+        self.set_window_fullscreen_and_layout(&window, false);
     }
 
     fn maximize_request(&mut self, surface: ToplevelSurface) {
@@ -254,7 +254,7 @@ impl XdgShellHandler for State {
             return;
         };
 
-        self.set_window_maximized(&window, true);
+        self.set_window_maximized_and_layout(&window, true);
     }
 
     fn unmaximize_request(&mut self, surface: ToplevelSurface) {
@@ -262,7 +262,7 @@ impl XdgShellHandler for State {
             return;
         };
 
-        self.set_window_maximized(&window, false);
+        self.set_window_maximized_and_layout(&window, false);
     }
 
     fn minimize_request(&mut self, _surface: ToplevelSurface) {

--- a/src/handlers/xwayland.rs
+++ b/src/handlers/xwayland.rs
@@ -3,7 +3,7 @@
 use std::{process::Stdio, time::Duration};
 
 use smithay::{
-    desktop::Window,
+    desktop::{space::SpaceElement, Window},
     input::pointer::CursorIcon,
     utils::{Logical, Point, Rectangle, Size, SERIAL_COUNTER},
     wayland::selection::{
@@ -27,7 +27,7 @@ use tracing::{debug, error, trace, warn};
 use crate::{
     focus::keyboard::KeyboardFocusTarget,
     state::{Pinnacle, State, WithState},
-    window::{window_state::FloatingOrTiled, WindowElement},
+    window::WindowElement,
 };
 
 impl XwmHandler for State {
@@ -47,8 +47,14 @@ impl XwmHandler for State {
             return;
         }
 
+        surface.set_mapped(true).expect("failed to map x11 window");
         let window = WindowElement::new(Window::new_x11_window(surface));
-        let bbox = window.bbox();
+
+        if let Some(output) = self.pinnacle.focused_output() {
+            window.place_on_output(output);
+        }
+
+        self.pinnacle.apply_window_rules(&window);
 
         let output_size = self
             .pinnacle
@@ -63,13 +69,17 @@ impl XwmHandler for State {
             .map(|op| op.current_location())
             .unwrap_or((0, 0).into());
 
+        let size = window
+            .with_state(|state| state.floating_size)
+            .unwrap_or(window.bbox().size);
+
         // Center the popup in the middle of the output.
         // Once I find a way to get an X11Surface's parent it will be centered on the parent if
         // applicable.
         // FIXME: loc is i32
         let loc: Point<i32, Logical> = (
-            output_loc.x + output_size.w / 2 - bbox.size.w / 2,
-            output_loc.y + output_size.h / 2 - bbox.size.h / 2,
+            output_loc.x + output_size.w / 2 - size.w / 2,
+            output_loc.y + output_size.h / 2 - size.h / 2,
         )
             .into();
 
@@ -77,29 +87,26 @@ impl XwmHandler for State {
             unreachable!()
         };
 
-        surface.set_mapped(true).expect("failed to map x11 window");
-
-        let bbox = Rectangle::from_loc_and_size(loc, bbox.size);
+        let geo = Rectangle::from_loc_and_size(loc, size);
 
         surface
-            .configure(bbox)
+            .configure(geo)
             .expect("failed to configure x11 window");
 
-        if let Some(output) = self.pinnacle.focused_output() {
-            window.place_on_output(output);
-        }
+        let will_float = should_float(surface)
+            || window.with_state(|state| state.floating_or_tiled.is_floating());
 
-        if should_float(surface) {
+        if will_float {
             window.with_state_mut(|state| {
-                state.floating_or_tiled = FloatingOrTiled::Floating {
-                    loc: bbox.loc.to_f64(),
-                    size: bbox.size,
+                if state.floating_loc.is_none() {
+                    state.floating_loc = Some(geo.loc.to_f64());
+                }
+                if state.floating_size.is_none() {
+                    tracing::info!(?geo.size);
+                    state.floating_size = Some(geo.size);
                 }
             });
-            self.pinnacle.space.map_element(window.clone(), loc, true);
         }
-
-        // TODO: do snapshot and transaction here BUT ONLY IF TILED AND ON ACTIVE TAG
 
         let output = window.output(&self.pinnacle);
 
@@ -110,15 +117,18 @@ impl XwmHandler for State {
         self.pinnacle.windows.push(window.clone());
         self.pinnacle.raise_window(window.clone(), true);
 
-        self.pinnacle.apply_window_rules(&window);
-
         if window.is_on_active_tag() {
             if let Some(output) = output {
                 output.with_state_mut(|state| state.focus_stack.set_focus(window.clone()));
                 self.update_keyboard_focus(&output);
 
-                self.pinnacle.begin_layout_transaction(&output);
-                self.pinnacle.request_layout(&output);
+                if will_float {
+                    self.pinnacle.set_window_floating(&window, true);
+                    self.pinnacle.space.map_element(window.clone(), loc, true);
+                } else {
+                    self.pinnacle.begin_layout_transaction(&output);
+                    self.pinnacle.request_layout(&output);
+                }
             }
         }
     }
@@ -184,7 +194,8 @@ impl XwmHandler for State {
         _reorder: Option<Reorder>,
     ) {
         trace!("XwmHandler::configure_request");
-        let floating_or_override_redirect = self
+        tracing::info!(?x, ?y, ?w, ?h);
+        let should_configure = self
             .pinnacle
             .windows
             .iter()
@@ -193,9 +204,11 @@ impl XwmHandler for State {
                 win.is_x11_override_redirect()
                     || win.with_state(|state| state.floating_or_tiled.is_floating())
             })
-            .unwrap_or(false);
+            .unwrap_or(true);
+        // If we unwrap_or here then the window hasn't requested a map yet.
+        // In that case, grant the configure. Xterm wants this to map properly, for example.
 
-        if floating_or_override_redirect {
+        if should_configure {
             let mut geo = window.geometry();
 
             if let Some(x) = x {
@@ -210,6 +223,8 @@ impl XwmHandler for State {
             if let Some(h) = h {
                 geo.size.h = h as i32;
             }
+
+            tracing::info!(?geo, "configure_request");
 
             if let Err(err) = window.configure(geo) {
                 error!("Failed to configure x11 win: {err}");
@@ -248,7 +263,7 @@ impl XwmHandler for State {
             return;
         };
 
-        self.set_window_maximized(&window, true);
+        self.set_window_maximized_and_layout(&window, true);
     }
 
     fn unmaximize_request(&mut self, _xwm: XwmId, window: X11Surface) {
@@ -259,7 +274,7 @@ impl XwmHandler for State {
             return;
         };
 
-        self.set_window_maximized(&window, false);
+        self.set_window_maximized_and_layout(&window, false);
     }
 
     fn fullscreen_request(&mut self, _xwm: XwmId, window: X11Surface) {
@@ -270,7 +285,7 @@ impl XwmHandler for State {
             return;
         };
 
-        self.set_window_fullscreen(&window, true);
+        self.set_window_fullscreen_and_layout(&window, true);
     }
 
     fn unfullscreen_request(&mut self, _xwm: XwmId, window: X11Surface) {
@@ -281,7 +296,7 @@ impl XwmHandler for State {
             return;
         };
 
-        self.set_window_fullscreen(&window, true);
+        self.set_window_fullscreen_and_layout(&window, true);
     }
 
     fn resize_request(

--- a/src/input.rs
+++ b/src/input.rs
@@ -218,7 +218,7 @@ impl Pinnacle {
             .filter(|win| win.is_on_active_tag())
             .enumerate()
         {
-            if win.with_state(|state| state.fullscreen_or_maximized.is_fullscreen()) {
+            if win.with_state(|state| state.window_state.is_fullscreen()) {
                 fullscreen_and_up_split_at = i + 1;
             }
         }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -17,10 +17,7 @@ use tracing::warn;
 use crate::{
     output::OutputName,
     state::{Pinnacle, State, WithState},
-    window::{
-        window_state::{FloatingOrTiled, FullscreenOrMaximized},
-        WindowElement,
-    },
+    window::{window_state::FullscreenOrMaximized, WindowElement},
 };
 
 use self::transaction::LayoutTransaction;
@@ -44,6 +41,13 @@ impl Pinnacle {
         });
 
         for win in to_unmap {
+            if win.with_state(|state| {
+                state.floating_or_tiled.is_floating() && state.fullscreen_or_maximized.is_neither()
+            }) {
+                if let Some(loc) = self.space.element_location(&win) {
+                    win.with_state_mut(|state| state.floating_loc = Some(loc.to_f64()));
+                }
+            }
             self.space.unmap_elem(&win);
         }
 
@@ -71,33 +75,33 @@ impl Pinnacle {
 
         for (win, geo) in zipped.by_ref() {
             win.change_geometry(geo.loc.to_f64(), geo.size);
+            self.space.map_element(win, geo.loc, false);
         }
 
         let (remaining_wins, _remaining_geos) = zipped.unzip::<_, _, Vec<_>, Vec<_>>();
 
         for win in remaining_wins {
             assert!(win.with_state(|state| state.floating_or_tiled.is_floating()));
-            win.toggle_floating();
+            self.set_window_floating(&win, true);
+            if let Some(toplevel) = win.toplevel() {
+                toplevel.send_pending_configure();
+            }
+            // TODO: will prolly need to map here
         }
 
         for window in windows_on_foc_tags.iter() {
             match window.with_state(|state| state.fullscreen_or_maximized) {
                 FullscreenOrMaximized::Fullscreen => {
                     window.change_geometry(output_geo.loc.to_f64(), output_geo.size);
+                    self.space
+                        .map_element(window.clone(), output_geo.loc, false);
                 }
                 FullscreenOrMaximized::Maximized => {
-                    window.change_geometry(
-                        (output_geo.loc + non_exclusive_geo.loc).to_f64(),
-                        non_exclusive_geo.size,
-                    );
+                    let loc = output_geo.loc + non_exclusive_geo.loc;
+                    window.change_geometry(loc.to_f64(), non_exclusive_geo.size);
+                    self.space.map_element(window.clone(), loc, false);
                 }
-                FullscreenOrMaximized::Neither => {
-                    if let FloatingOrTiled::Floating { loc, size } =
-                        window.with_state(|state| state.floating_or_tiled)
-                    {
-                        window.change_geometry(loc, size);
-                    }
-                }
+                FullscreenOrMaximized::Neither => (),
             }
         }
 
@@ -110,10 +114,17 @@ impl Pinnacle {
                 }
             }
 
-            // TODO: get rid of target_loc
-            let loc = win.with_state_mut(|state| state.target_loc.take());
-            if let Some(loc) = loc {
-                self.space.map_element(win.clone(), loc, false);
+            let floating_loc = win
+                .with_state(|state| {
+                    let should_map = state.floating_or_tiled.is_floating()
+                        && state.fullscreen_or_maximized.is_neither();
+
+                    should_map.then_some(state.floating_loc)
+                })
+                .flatten();
+            if let Some(loc) = floating_loc {
+                self.space
+                    .map_element(win.clone(), loc.to_i32_round(), false);
             }
         }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -214,7 +214,7 @@ impl Pinnacle {
                 .windows
                 .iter()
                 .filter(|win| win.output(self).as_ref() == Some(output))
-                .filter(|win| win.with_state(|state| state.floating_or_tiled.is_floating()))
+                .filter(|win| win.with_state(|state| state.window_state.is_floating()))
                 .cloned()
                 .collect::<Vec<_>>()
             {

--- a/src/render.rs
+++ b/src/render.rs
@@ -247,7 +247,7 @@ fn window_render_elements<R: PRenderer>(
         .rev() // rev because I treat the focus stack backwards vs how the renderer orders it
         .enumerate()
         .map(|(i, win)| {
-            if win.with_state(|state| state.fullscreen_or_maximized.is_fullscreen()) {
+            if win.with_state(|state| state.window_state.is_fullscreen()) {
                 last_fullscreen_split_at = i + 1;
             }
 

--- a/src/render/util/snapshot.rs
+++ b/src/render/util/snapshot.rs
@@ -182,9 +182,9 @@ pub fn capture_snapshots_on_output(
         .filter(|win| {
             win.is_on_active_tag_on_output(output)
                 || (win.is_on_active_tag()
-                    && win.with_state(|state| state.floating_or_tiled.is_floating()))
+                    && win.with_state(|state| state.window_state.is_floating()))
         })
-        .position(|win| win.with_state(|state| state.fullscreen_or_maximized.is_fullscreen()));
+        .position(|win| win.with_state(|state| state.window_state.is_fullscreen()));
 
     let mut under_fullscreen = pinnacle
         .space
@@ -192,7 +192,7 @@ pub fn capture_snapshots_on_output(
         .filter(|win| {
             win.is_on_active_tag_on_output(output)
                 || (win.is_on_active_tag()
-                    && win.with_state(|state| state.floating_or_tiled.is_floating()))
+                    && win.with_state(|state| state.window_state.is_floating()))
         })
         .cloned()
         .collect::<Vec<_>>();
@@ -203,8 +203,7 @@ pub fn capture_snapshots_on_output(
     let also_include = also_include.into_iter().collect::<HashSet<_>>();
 
     let mut flat_map = |win: WindowElement| {
-        if win.with_state(|state| state.floating_or_tiled.is_tiled()) || also_include.contains(&win)
-        {
+        if win.with_state(|state| state.window_state.is_tiled()) || also_include.contains(&win) {
             let loc = pinnacle.space.element_location(&win)? - output.current_location();
             let snapshot = win.capture_snapshot_and_store(
                 renderer,

--- a/src/window.rs
+++ b/src/window.rs
@@ -73,10 +73,10 @@ impl WindowElement {
             }
         }
 
-        self.with_state_mut(|state| {
-            // FIXME: f64 -> i32, also remove target loc
-            state.target_loc = Some(new_loc.to_i32_round());
-        });
+        // self.with_state_mut(|state| {
+        //     // FIXME: f64 -> i32, also remove target loc
+        //     state.target_loc = Some(new_loc.to_i32_round());
+        // });
     }
 
     /// Get this window's class (app id in Wayland but hey old habits die hard).

--- a/src/window/rules.rs
+++ b/src/window/rules.rs
@@ -200,13 +200,24 @@ impl Pinnacle {
                     window.with_state_mut(|state| state.tags.clone_from(&tags));
                 }
 
+                if let Some(floating_or_tiled) = floating_or_tiled {
+                    window.with_state_mut(|state| {
+                        state.window_state.set_floating(match floating_or_tiled {
+                            FloatingOrTiled::Floating => true,
+                            FloatingOrTiled::Tiled => false,
+                        })
+                    });
+                }
+
                 if let Some(fs_or_max) = fullscreen_or_maximized {
                     match fs_or_max {
-                        FullscreenOrMaximized::Neither => (), // TODO: is this branch needed?
+                        FullscreenOrMaximized::Neither => (), // TODO:
                         FullscreenOrMaximized::Fullscreen => {
-                            self.set_window_fullscreen(window, true)
+                            window.with_state_mut(|state| state.window_state.set_fullscreen(true));
                         }
-                        FullscreenOrMaximized::Maximized => self.set_window_maximized(window, true),
+                        FullscreenOrMaximized::Maximized => {
+                            window.with_state_mut(|state| state.window_state.set_maximized(true))
+                        }
                     }
                 }
 
@@ -225,10 +236,6 @@ impl Pinnacle {
                     window.with_state_mut(|state| {
                         state.floating_loc = Some(Point::from(*location).to_f64());
                     });
-                }
-
-                if let Some(floating_or_tiled) = floating_or_tiled {
-                    window.with_state_mut(|state| state.floating_or_tiled = *floating_or_tiled);
                 }
 
                 if let Some(decoration_mode) = decoration_mode {

--- a/wlcs_pinnacle/src/main_loop.rs
+++ b/wlcs_pinnacle/src/main_loop.rs
@@ -120,9 +120,10 @@ fn handle_event(event: WlcsEvent, state: &mut State) {
             if let Some(window) = window {
                 window.with_state_mut(|state| {
                     state.floating_loc = Some(location.to_f64());
+                    // state.window_state.set_floating(true);
                 });
 
-                state.pinnacle.set_window_floating(&window, true);
+                // state.pinnacle.set_window_floating(&window, true);
 
                 state
                     .pinnacle


### PR DESCRIPTION
This PR comes with improvements to window state handling (floating, fullscreen, maximized).

Improvements include:
- Pinnacle will now *finally* attempt to open Wayland windows as floating when necessary, like the save prompt in Firefox. This closes #85 which was opened a whopping 9 months ago haha
- Fixed the bit where you could drag fullscreen and maximized windows when the window was previously floating
- Fixed xterm taking like 5 seconds to open
    - In classic xwayland fashion, this introduces a regression where you now need to run Intellij Idea with `_JAVA_AWT_WM_NONREPARENTING=1` to get it to appear correctly

Things that need doing and thinking about:
- [x] I *really* don't like what `WindowElementState::floating_or_tiled` is doing. It's currently pulling double duty as the holder for the current floating/tiled state of the window *and* it gets used as a marker for what state gets applied when exiting fullscreen or tiled mode; both "prescription" and "description". Find a way to separate its duties.
    - Unified `floating_or_tiled` with the `fullscreen_or_maximized` state, which now feeds into `Pinnacle::update_window_state`.
- [x] As a result of the above, the API should be updated to unify those states into something like `enum { Tiled, Floating, Fullscreen, Maximized }`