### PR TITLE
Rendering improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,12 +508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,17 +2181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "image"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
-dependencies = [
- "bytemuck",
- "byteorder",
- "num-traits",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3288,7 +3271,6 @@ dependencies = [
  "dircpy",
  "drm-sys",
  "gag",
- "image",
  "indexmap 2.2.6",
  "libdisplay-info-sys",
  "pinnacle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,6 @@ anyhow = { version = "1.0.86", features = ["backtrace"] }
 thiserror = "1.0.61"
 # xcursor stuff
 xcursor = { version = "0.3.5" }
-image = { version = "0.25.1", default-features = false }
 # gRPC
 prost = { workspace = true }
 tonic = { workspace = true }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1343,7 +1343,9 @@ impl output_service_server::OutputService for OutputService {
                 return;
             };
 
-            state.backend.set_output_powered(&output, powered);
+            state
+                .backend
+                .set_output_powered(&output, &state.pinnacle.loop_handle, powered);
 
             if powered {
                 state.schedule_render(&output);

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -7,7 +7,7 @@ use smithay::{
     },
     delegate_dmabuf,
     output::Output,
-    reexports::wayland_server::protocol::wl_surface::WlSurface,
+    reexports::{calloop::LoopHandle, wayland_server::protocol::wl_surface::WlSurface},
     wayland::dmabuf::{DmabufGlobal, DmabufHandler, DmabufState, ImportNotifier},
 };
 use tracing::error;
@@ -98,10 +98,15 @@ impl Backend {
         }
     }
 
-    pub fn set_output_powered(&mut self, output: &Output, powered: bool) {
+    pub fn set_output_powered(
+        &mut self,
+        output: &Output,
+        loop_handle: &LoopHandle<'static, State>,
+        powered: bool,
+    ) {
         match self {
             Backend::Winit(_) => (),
-            Backend::Udev(udev) => udev.set_output_powered(output, powered),
+            Backend::Udev(udev) => udev.set_output_powered(output, loop_handle, powered),
             #[cfg(feature = "testing")]
             Backend::Dummy(dummy) => dummy.set_output_powered(output, powered),
         }
@@ -122,7 +127,7 @@ impl Backend {
                 }
             }
             #[cfg(feature = "testing")]
-            Backend::Dummy(_) => todo!(),
+            Backend::Dummy(_) => (),
         }
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -113,21 +113,16 @@ impl Backend {
     }
 
     pub fn render_scheduled_outputs(&mut self, pinnacle: &mut Pinnacle) {
-        match self {
-            Backend::Winit(winit) => winit.render_if_scheduled(pinnacle),
-            Backend::Udev(udev) => {
-                for output in pinnacle
-                    .outputs
-                    .iter()
-                    .filter(|(_, global)| global.is_some())
-                    .map(|(op, _)| op.clone())
-                    .collect::<Vec<_>>()
-                {
-                    udev.render_if_scheduled(pinnacle, &output);
-                }
+        if let Backend::Udev(udev) = self {
+            for output in pinnacle
+                .outputs
+                .iter()
+                .filter(|(_, global)| global.is_some())
+                .map(|(op, _)| op.clone())
+                .collect::<Vec<_>>()
+            {
+                udev.render_if_scheduled(pinnacle, &output);
             }
-            #[cfg(feature = "testing")]
-            Backend::Dummy(_) => (),
         }
     }
 

--- a/src/backend/udev/frame.rs
+++ b/src/backend/udev/frame.rs
@@ -1,0 +1,78 @@
+use std::{num::NonZeroU64, time::Duration};
+
+use smithay::utils::{Clock, Monotonic};
+use tracing::error;
+
+pub struct FrameClock {
+    last_presentation_time: Option<Duration>,
+    refresh_interval_ns: Option<NonZeroU64>,
+    // TODO: vrr
+}
+
+impl FrameClock {
+    // TODO: vrr
+    pub fn new(refresh_interval: Option<Duration>) -> Self {
+        let refresh_interval_ns = refresh_interval.map(|interval| {
+            assert_eq!(interval.as_secs(), 0);
+            NonZeroU64::new(interval.subsec_nanos().into()).unwrap()
+        });
+
+        Self {
+            last_presentation_time: None,
+            refresh_interval_ns,
+        }
+    }
+
+    pub fn refresh_interval(&self) -> Option<Duration> {
+        self.refresh_interval_ns
+            .map(|ns| Duration::from_nanos(ns.get()))
+    }
+
+    pub fn presented(&mut self, presentation_time: Duration) {
+        if presentation_time.is_zero() {
+            // Not interested in these
+            return;
+        }
+
+        self.last_presentation_time = Some(presentation_time);
+    }
+
+    /// Returns the amount of time from now to the time of the next estimated presentation.
+    pub fn time_to_next_presentation(&self, clock: &Clock<Monotonic>) -> Duration {
+        let mut now: Duration = clock.now().into();
+
+        let Some(refresh_interval_ns) = self.refresh_interval_ns else {
+            return Duration::ZERO;
+        };
+
+        let Some(last_presentation_time) = self.last_presentation_time else {
+            return Duration::ZERO;
+        };
+
+        let refresh_interval_ns = refresh_interval_ns.get();
+
+        if now <= last_presentation_time {
+            // Got an early vblank
+            let orig_now = now;
+            now += Duration::from_nanos(refresh_interval_ns);
+
+            if now < last_presentation_time {
+                // Not sure when this can happen
+                error!(
+                    now = ?orig_now,
+                    ?last_presentation_time,
+                    "Got a 2+ early vblank, {:?} until presentation",
+                    last_presentation_time - now,
+                );
+                now = last_presentation_time + Duration::from_nanos(refresh_interval_ns);
+            }
+        }
+
+        let duration_since_last = now - last_presentation_time;
+        let ns_since_last = duration_since_last.as_nanos() as u64;
+        let ns_to_next = (ns_since_last / refresh_interval_ns + 1) * refresh_interval_ns;
+
+        // TODO: vrr
+        last_presentation_time + Duration::from_nanos(ns_to_next) - now
+    }
+}

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -44,7 +44,7 @@ use crate::{
     state::{Pinnacle, State, WithState},
 };
 
-use super::{Backend, BackendData, RenderResult, UninitBackend};
+use super::{Backend, BackendData, UninitBackend};
 
 const LOGO_BYTES: &[u8] = include_bytes!("../../resources/pinnacle_logo_icon.rgba");
 
@@ -244,7 +244,6 @@ impl Winit {
 
     /// Schedule a render on the winit window.
     pub fn schedule_render(&mut self) {
-        trace!("Scheduling winit render");
         self.output_render_scheduled = true;
     }
 
@@ -255,7 +254,7 @@ impl Winit {
         }
     }
 
-    pub(super) fn render_winit_window(&mut self, pinnacle: &mut Pinnacle) -> RenderResult {
+    pub(super) fn render_winit_window(&mut self, pinnacle: &mut Pinnacle) {
         let full_redraw = &mut self.full_redraw;
         *full_redraw = full_redraw.saturating_sub(1);
 
@@ -377,7 +376,7 @@ impl Winit {
                 })
         });
 
-        let render_result = match render_res {
+        match render_res {
             Ok(render_output_result) => {
                 if pinnacle.lock_state.is_unlocked() {
                     Winit::handle_pending_screencopy(
@@ -425,14 +424,10 @@ impl Winit {
                         0,
                         wp_presentation_feedback::Kind::Vsync,
                     );
-                    RenderResult::Submitted
-                } else {
-                    RenderResult::NoDamage
                 }
             }
             Err(err) => {
                 warn!("{}", err);
-                RenderResult::Skipped
             }
         };
 
@@ -445,8 +440,6 @@ impl Winit {
         if render_after_transaction_finish {
             self.schedule_render();
         }
-
-        render_result
     }
 }
 

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -16,7 +16,6 @@ use smithay::{
         },
         winit::{self, WinitEvent, WinitGraphicsBackend},
     },
-    input::pointer::CursorImageStatus,
     output::{Output, Scale, Subpixel},
     reexports::{
         calloop::{self, generic::Generic, Interest, LoopHandle, PostAction},
@@ -30,7 +29,7 @@ use smithay::{
             window::{Icon, WindowAttributes},
         },
     },
-    utils::{IsAlive, Point, Rectangle, Transform},
+    utils::{Point, Rectangle, Transform},
     wayland::dmabuf::{self, DmabufFeedback, DmabufFeedbackBuilder, DmabufGlobal, DmabufState},
 };
 use tracing::{debug, error, trace, warn};
@@ -53,7 +52,6 @@ pub struct Winit {
     pub damage_tracker: OutputDamageTracker,
     pub dmabuf_state: (DmabufState, DmabufGlobal, Option<DmabufFeedback>),
     pub full_redraw: u8,
-    output_render_scheduled: bool,
     output: Output,
 }
 
@@ -173,7 +171,6 @@ impl Winit {
             damage_tracker: OutputDamageTracker::from_output(&output),
             dmabuf_state,
             full_redraw: 0,
-            output_render_scheduled: false,
             output,
         };
 
@@ -222,10 +219,10 @@ impl Winit {
                             state.process_input_event(input_evt);
                         }
                         WinitEvent::Redraw => {
-                            // let winit = state.backend.winit_mut();
-                            // winit.output_render_scheduled = true;
-                            // winit.render_if_scheduled(&mut state.pinnacle);
-                            state.backend.winit_mut().schedule_render();
+                            state
+                                .backend
+                                .winit_mut()
+                                .render_winit_window(&mut state.pinnacle);
                         }
                         WinitEvent::CloseRequested => {
                             state.pinnacle.shutdown();
@@ -244,27 +241,12 @@ impl Winit {
 
     /// Schedule a render on the winit window.
     pub fn schedule_render(&mut self) {
-        self.output_render_scheduled = true;
+        self.backend.window().request_redraw();
     }
 
-    /// Render the winit window if a render has been scheduled.
-    pub fn render_if_scheduled(&mut self, pinnacle: &mut Pinnacle) {
-        if self.output_render_scheduled {
-            self.render_winit_window(pinnacle);
-        }
-    }
-
-    pub(super) fn render_winit_window(&mut self, pinnacle: &mut Pinnacle) {
+    fn render_winit_window(&mut self, pinnacle: &mut Pinnacle) {
         let full_redraw = &mut self.full_redraw;
         *full_redraw = full_redraw.saturating_sub(1);
-
-        if let CursorImageStatus::Surface(surface) = pinnacle.cursor_state.cursor_image() {
-            if !surface.alive() {
-                pinnacle
-                    .cursor_state
-                    .set_cursor_image(CursorImageStatus::default_named());
-            }
-        }
 
         // The z-index of these is determined by `state.fixup_z_layering()`, which is called at the end
         // of every event loop cycle
@@ -433,11 +415,8 @@ impl Winit {
 
         pinnacle.send_frame_callbacks(&self.output, None);
 
-        assert!(self.output_render_scheduled);
-        self.output_render_scheduled = false;
-
         // At the end cuz borrow checker
-        if render_after_transaction_finish {
+        if render_after_transaction_finish || pinnacle.cursor_state.is_current_cursor_animated() {
             self.schedule_render();
         }
     }
@@ -454,7 +433,7 @@ impl Winit {
             return;
         };
 
-        assert!(screencopy.output() == output);
+        assert_eq!(screencopy.output(), output);
 
         if screencopy.with_damage() {
             match render_output_result.damage.as_ref() {

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -109,6 +109,10 @@ impl OutputFocusStack {
         self.stack.retain(|op| op != &output);
         self.stack.push(output);
     }
+
+    pub fn remove(&mut self, output: &Output) {
+        self.stack.retain(|op| op != output);
+    }
 }
 
 /// A stack of windows, with the top one being the one in focus.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -423,6 +423,15 @@ impl CompositorHandler for State {
             .cloned()
         {
             vec![output] // surface is a layer surface
+        } else if matches!(self.pinnacle.cursor_state.cursor_image(), CursorImageStatus::Surface(s) if s == surface)
+        {
+            // This is a cursor surface
+            // TODO: granular
+            self.pinnacle.space.outputs().cloned().collect()
+        } else if self.pinnacle.dnd_icon.as_ref() == Some(surface) {
+            // This is a dnd icon
+            // TODO: granular
+            self.pinnacle.space.outputs().cloned().collect()
         } else if let Some(output) = self
             .pinnacle
             .space

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -154,7 +154,7 @@ impl CompositorHandler for State {
     }
 
     fn commit(&mut self, surface: &WlSurface) {
-        trace!("commit on surface {surface:?}");
+        // tracing::info!("commit on surface {surface:?}");
 
         utils::on_commit_buffer_handler::<State>(surface);
 
@@ -273,6 +273,13 @@ impl CompositorHandler for State {
                             } else {
                                 self.pinnacle.begin_layout_transaction(&focused_output);
                                 self.pinnacle.request_layout(&focused_output);
+
+                                // FIXME: Map immediately to get the primary scanout output to be correct
+                                // self.pinnacle.space.map_element(
+                                //     unmapped_window.clone(),
+                                //     focused_output.current_location(),
+                                //     true,
+                                // );
                             }
 
                             // It seems wlcs needs immediate frame sends for client tests to work

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -928,7 +928,8 @@ impl OutputManagementHandler for State {
                 OutputConfiguration::Disabled => {
                     self.pinnacle.set_output_enabled(&output, false);
                     // TODO: split
-                    self.backend.set_output_powered(&output, false);
+                    self.backend
+                        .set_output_powered(&output, &self.pinnacle.loop_handle, false);
                 }
                 OutputConfiguration::Enabled {
                     mode,
@@ -939,7 +940,8 @@ impl OutputManagementHandler for State {
                 } => {
                     self.pinnacle.set_output_enabled(&output, true);
                     // TODO: split
-                    self.backend.set_output_powered(&output, true);
+                    self.backend
+                        .set_output_powered(&output, &self.pinnacle.loop_handle, true);
 
                     self.capture_snapshots_on_output(&output, []);
 
@@ -1001,7 +1003,8 @@ impl OutputPowerManagementHandler for State {
     }
 
     fn set_mode(&mut self, output: &Output, powered: bool) {
-        self.backend.set_output_powered(output, powered);
+        self.backend
+            .set_output_powered(output, &self.pinnacle.loop_handle, powered);
 
         if powered {
             self.schedule_render(output);

--- a/src/layout/transaction.rs
+++ b/src/layout/transaction.rs
@@ -7,18 +7,14 @@ use std::{
 
 use smithay::{
     backend::renderer::element::{
-        self,
-        surface::WaylandSurfaceRenderElement,
-        texture::{TextureBuffer, TextureRenderElement},
-        utils::RescaleRenderElement,
-        Element,
+        surface::WaylandSurfaceRenderElement, utils::RescaleRenderElement, Element,
     },
     desktop::Space,
     reexports::calloop::{
         timer::{TimeoutAction, Timer},
         LoopHandle,
     },
-    utils::{Logical, Point, Scale, Serial, Transform},
+    utils::{Logical, Point, Scale, Serial},
 };
 
 use crate::{

--- a/src/output.rs
+++ b/src/output.rs
@@ -349,6 +349,8 @@ impl Pinnacle {
 
         self.space.unmap_output(output);
 
+        self.output_focus_stack.remove(output);
+
         self.gamma_control_manager_state.output_removed(output);
 
         self.output_power_management_state.output_removed(output);

--- a/src/output.rs
+++ b/src/output.rs
@@ -13,6 +13,7 @@ use smithay::{
     utils::{Logical, Point, Transform},
     wayland::session_lock::LockSurface,
 };
+use tracing::debug;
 
 use crate::{
     backend::BackendData,
@@ -333,6 +334,8 @@ impl Pinnacle {
 
     /// Completely remove an output, for example when a monitor is unplugged
     pub fn remove_output(&mut self, output: &Output) {
+        debug!("Removing output {}", output.name());
+
         let global = self.outputs.shift_remove(output);
         if let Some(mut global) = global {
             if let Some(global) = global.take() {

--- a/src/render.rs
+++ b/src/render.rs
@@ -29,7 +29,7 @@ use smithay::{
 
 use crate::{
     backend::{udev::UdevRenderer, Backend},
-    layout::transaction::{LayoutTransaction, SnapshotRenderElement, SnapshotTarget},
+    layout::transaction::SnapshotRenderElement,
     pinnacle_render_elements,
     state::{State, WithState},
     window::WindowElement,

--- a/src/render/util/snapshot.rs
+++ b/src/render/util/snapshot.rs
@@ -210,7 +210,10 @@ pub fn capture_snapshots_on_output(
                 1.0,
             );
 
-            snapshot.map(SnapshotTarget::Snapshot)
+            snapshot.map(|ss| SnapshotTarget::Snapshot {
+                snapshot: ss,
+                window: win.clone(),
+            })
         } else {
             Some(SnapshotTarget::Window(win))
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -221,6 +221,7 @@ impl State {
     pub fn on_event_loop_cycle_completion(&mut self) {
         self.pinnacle.fixup_z_layering();
         self.pinnacle.space.refresh();
+        self.pinnacle.cursor_state.cleanup();
         self.pinnacle.popup_manager.cleanup();
         self.update_pointer_focus();
         foreign_toplevel::refresh(self);

--- a/src/state.rs
+++ b/src/state.rs
@@ -243,15 +243,14 @@ impl State {
 
         // FIXME: Don't poll this every cycle
         for output in self.pinnacle.space.outputs().cloned().collect::<Vec<_>>() {
-            output.with_state_mut(|state| {
-                if state
+            if output.with_state_mut(|state| {
+                state
                     .layout_transaction
                     .as_ref()
                     .is_some_and(|ts| ts.ready())
-                {
-                    self.schedule_render(&output);
-                }
-            });
+            }) {
+                self.schedule_render(&output);
+            }
         }
 
         self.pinnacle

--- a/src/window/window_state.rs
+++ b/src/window/window_state.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use indexmap::IndexSet;
 use smithay::{
+    backend::renderer::element::Id,
     desktop::{space::SpaceElement, WindowSurface},
     reexports::wayland_protocols::xdg::shell::server::xdg_toplevel,
     utils::{Logical, Point, Serial, Size},
@@ -206,6 +207,7 @@ pub struct WindowElementState {
     pub decoration_mode: Option<DecorationMode>,
     pub floating_loc: Option<Point<f64, Logical>>,
     pub floating_size: Option<Size<i32, Logical>>,
+    pub offscreen_elem_id: Option<Id>,
 }
 
 impl WindowElement {
@@ -425,6 +427,7 @@ impl WindowElementState {
             snapshot: None,
             snapshot_hook_id: None,
             decoration_mode: None,
+            offscreen_elem_id: None,
         }
     }
 }

--- a/src/window/window_state.rs
+++ b/src/window/window_state.rs
@@ -207,6 +207,16 @@ pub struct WindowElementState {
     pub decoration_mode: Option<DecorationMode>,
     pub floating_loc: Option<Point<f64, Logical>>,
     pub floating_size: Option<Size<i32, Logical>>,
+
+    /// The id of a snapshot element if any.
+    ///
+    /// When updating the primary scanout output, Smithay looks at the ids of all elements drawn on
+    /// screen. If it matches the ids of this window's elements, the primary output is updated.
+    /// However, when a snapshot is rendering, the snapshot's element id is different from this
+    /// window's ids. Therefore, we clone that snapshot's id into this field and use it to update
+    /// the primary output when necessary.
+    ///
+    /// See [`Pinnacle::update_primary_scanout_output`] for more details.
     pub offscreen_elem_id: Option<Id>,
 }
 


### PR DESCRIPTION
This PR brings Pinnacle's rendering loop more in line with niri and cosmic-comp. Specifically, it:
- Properly throttles rendering such that frame submissions with no damage wait for a frame before allowing another render
- Prevents clients from busy-looping commits by only allowing sending frame callbacks once per vblank

As a result, rendering performance has improved by quite a bit. A YouTube video used to take around 6-7% of my CPU; now it takes around 1%.

TODO:
- [x] Some things that caused a render before may not currently
- [x] There are some unnecessary return values from rendering that need to be cleaned up
- [x] There's a match branch that should be unreachable but it isn't because things are ordered slightly differently than niri
- [x] Document the use of the offscreen element id when updating the primary scanout output
- [x] Test frametimes and fluidity in games and stuff, there could be non-obvious frametime regressions and there's no profiling yet
- [x] Test animated cursors and also change `time_until_next_animated_cursor_frame` to `is_animated`
- [x] Clippy n stuff
- [x] Turning a monitor off and on causes all windows on that output to only redraw once a second

Should fix #266