### PR TITLE
Add window focused signal

### DIFF
--- a/api/lua/pinnacle/signal.lua
+++ b/api/lua/pinnacle/signal.lua
@@ -57,6 +57,14 @@ local signals = {
         ---@type fun(response: table)
         on_response = nil,
     },
+    WindowFocused = {
+        ---@type grpc_client.h2.Stream?
+        sender = nil,
+        ---@type (fun(window: WindowHandle))[]
+        callbacks = {},
+        ---@type fun(response: table)
+        on_response = nil,
+    },
     TagActive = {
         ---@type grpc_client.h2.Stream?
         sender = nil,
@@ -121,6 +129,15 @@ signals.WindowPointerLeave.on_response = function(response)
     local window_handle = require("pinnacle.window").handle.new(response.window_id)
 
     for _, callback in ipairs(signals.WindowPointerLeave.callbacks) do
+        callback(window_handle)
+    end
+end
+
+signals.WindowFocused.on_response = function(response)
+    ---@diagnostic disable-next-line: invisible
+    local window_handle = require("pinnacle.window").handle.new(response.window_id)
+
+    for _, callback in ipairs(signals.WindowFocused.callbacks) do
         callback(window_handle)
     end
 end

--- a/api/lua/pinnacle/window.lua
+++ b/api/lua/pinnacle/window.lua
@@ -145,11 +145,13 @@ require("pinnacle.util").make_bijective(layout_mode)
 local signal_name_to_SignalName = {
     pointer_enter = "WindowPointerEnter",
     pointer_leave = "WindowPointerLeave",
+    focused = "WindowFocused",
 }
 
 ---@class WindowSignal Signals related to compositor events.
 ---@field pointer_enter fun(window: WindowHandle)? The pointer entered a window.
 ---@field pointer_leave fun(window: WindowHandle)? The pointer left a window.
+---@field focused fun(window: WindowHandle)? The window got keyboard focus.
 
 ---Connects to a window signal.
 ---

--- a/api/protobuf/pinnacle/signal/v1/signal.proto
+++ b/api/protobuf/pinnacle/signal/v1/signal.proto
@@ -61,6 +61,14 @@ message WindowPointerLeaveResponse {
     uint32 window_id = 1;
 }
 
+message WindowFocusedRequest {
+    StreamControl control = 1;
+}
+message WindowFocusedResponse {
+    // The window that got focus.
+    uint32 window_id = 1;
+}
+
 message TagActiveRequest {
     StreamControl control = 1;
 }
@@ -85,6 +93,7 @@ service SignalService {
     
     rpc WindowPointerEnter(stream WindowPointerEnterRequest) returns (stream WindowPointerEnterResponse);
     rpc WindowPointerLeave(stream WindowPointerLeaveRequest) returns (stream WindowPointerLeaveResponse);
+    rpc WindowFocused(stream WindowFocusedRequest) returns (stream WindowFocusedResponse);
     
     rpc TagActive(stream TagActiveRequest) returns (stream TagActiveResponse);
 

--- a/api/rust/src/signal.rs
+++ b/api/rust/src/signal.rs
@@ -218,6 +218,21 @@ signals! {
                 }
             },
         }
+        /// The window got keyboard focus.
+        ///
+        /// Callbacks receive the window gets focus.
+        WindowFocused = {
+            enum_name = Focused,
+            callback_type = SingleWindowFn,
+            client_request = window_focused,
+            on_response = |response, callbacks| {
+                let handle = WindowHandle { id: response.window_id };
+
+                for callback in callbacks {
+                    callback(&handle);
+                }
+            },
+        }
     }
     /// Signals relating to tag events.
     TagSignal => {
@@ -264,6 +279,7 @@ pub(crate) struct SignalState {
 
     pub(crate) window_pointer_enter: SignalData<WindowPointerEnter>,
     pub(crate) window_pointer_leave: SignalData<WindowPointerLeave>,
+    pub(crate) window_focused: SignalData<WindowFocused>,
 
     pub(crate) tag_active: SignalData<TagActive>,
 
@@ -285,6 +301,7 @@ impl SignalState {
             output_move: SignalData::new(),
             window_pointer_enter: SignalData::new(),
             window_pointer_leave: SignalData::new(),
+            window_focused: SignalData::new(),
             tag_active: SignalData::new(),
             input_device_added: SignalData::new(),
         }
@@ -297,6 +314,7 @@ impl SignalState {
         self.output_move.reset();
         self.window_pointer_enter.reset();
         self.window_pointer_leave.reset();
+        self.window_focused.reset();
         self.tag_active.reset();
         self.input_device_added.reset();
     }

--- a/api/rust/src/window.rs
+++ b/api/rust/src/window.rs
@@ -153,6 +153,7 @@ pub fn connect_signal(signal: WindowSignal) -> SignalHandle {
     match signal {
         WindowSignal::PointerEnter(f) => signal_state.window_pointer_enter.add_callback(f),
         WindowSignal::PointerLeave(f) => signal_state.window_pointer_leave.add_callback(f),
+        WindowSignal::Focused(f) => signal_state.window_focused.add_callback(f),
     }
 }
 

--- a/pinnacle-api-defs/src/lib.rs
+++ b/pinnacle-api-defs/src/lib.rs
@@ -68,6 +68,7 @@ pub mod pinnacle {
                 OutputMoveRequest,
                 WindowPointerEnterRequest,
                 WindowPointerLeaveRequest,
+                WindowFocusedRequest,
                 TagActiveRequest,
                 InputDeviceAddedRequest
             );

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -4,6 +4,7 @@ use keyboard::KeyboardFocusTarget;
 use smithay::{desktop::space::SpaceElement, output::Output, utils::SERIAL_COUNTER};
 
 use crate::{
+    api::signal::Signal,
     state::{Pinnacle, State, WithState},
     window::WindowElement,
 };
@@ -39,6 +40,10 @@ impl State {
                     toplevel.send_pending_configure();
                 }
             }
+            self.pinnacle
+                .signal_state
+                .window_focused
+                .signal(focused_win);
         }
 
         keyboard.set_focus(


### PR DESCRIPTION
This PR adds a new signal that gets triggered whenever a window receives keyboard focus. I've tested the core functionality and it works as expected, though I haven't tested the Lua API yet (it's a bit tricky to set up on NixOS).

This is just the first of several signals I'm planning to add. My goal is to implement enough signals to replicate the dwl format for yambar integration, as I'd like to make pinnacle my daily driver.

Personal note: I'm really excited about this project! I've tried many Wayland compositors, and was actually planning to write my own because each existing one was missing something crucial. Then I found pinnacle, and it's exactly what I was looking for. Really happy to be able to contribute.
