### PR TITLE
feature: enable use of wgpu instance flag environment variables

### DIFF
--- a/snowcap/src/wgpu.rs
+++ b/snowcap/src/wgpu.rs
@@ -25,6 +25,7 @@ pub struct Wgpu {
 pub fn setup_wgpu() -> anyhow::Result<Wgpu> {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::VULKAN,
+        flags: wgpu::InstanceFlags::default().with_env(),
         ..Default::default()
     });
 


### PR DESCRIPTION
Makes `pinnacle` (and specifically `snowcap`) use the WGPU environment variables for modifying [`InstanceFlags`](https://docs.rs/wgpu/25.0.0/wgpu/struct.InstanceFlags.html#method.with_env).

Should close issue #314 :3 