### PR TITLE
Implement tiled resizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6ae361963ea5fe52038156ea1729f3b4e4ccc0711c362ab2b2d2c0a259e7c3"
+checksum = "71b01d27060ad58be4663b9e4ac9e2d4806918e8876af8912afbddd1a91d5eaa"
 
 [[package]]
 name = "guillotiere"
@@ -4255,9 +4255,8 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a844965df28147d726ecc321bf67f287a9bdec5a655f53d4e7e5cad20443dc"
+version = "0.8.2"
+source = "git+https://github.com/Ottatop/taffy?rev=dcdaa42#dcdaa42e0ed220cac60da1455caf589907794e62"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ indexmap = { workspace = true }
 snowcap = { path = "./snowcap", optional = true }
 snowcap-api = { path = "./snowcap/api/rust", optional = true }
 assert_matches = "1.5.0"
-taffy = "0.8.0"
+taffy = "=0.8.2" # Patched below for rounding fixes
 slab_tree = "0.3.2"
 bimap = "0.6.3"
 itertools = "0.14.0"
@@ -175,3 +175,6 @@ lto = "thin"
 
 [lints]
 workspace = true
+
+[patch.crates-io]
+taffy = { git = "https://github.com/Ottatop/taffy", rev = "dcdaa42" } # Rounding fixes

--- a/src/api/layout/v1.rs
+++ b/src/api/layout/v1.rs
@@ -103,6 +103,7 @@ impl TryFrom<layout::v1::LayoutNode> for crate::layout::tree::LayoutNode {
                 layout::v1::FlexDir::Column => taffy::FlexDirection::Column,
             },
             flex_basis: taffy::Dimension::percent(style.size_proportion),
+            flex_grow: 1.0,
             margin: style
                 .gaps
                 .map(|gaps| taffy::Rect {

--- a/src/grab/resize_grab.rs
+++ b/src/grab/resize_grab.rs
@@ -22,6 +22,7 @@ use smithay::{
 use tracing::warn;
 
 use crate::{
+    layout::tree::ResizeDir,
     state::{State, WithState},
     util::transaction::TransactionBuilder,
     window::WindowElement,
@@ -117,31 +118,34 @@ impl PointerGrab<State> for ResizeSurfaceGrab {
 
     fn motion(
         &mut self,
-        data: &mut State,
+        state: &mut State,
         handle: &mut PointerInnerHandle<'_, State>,
         _focus: Option<(<State as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &smithay::input::pointer::MotionEvent,
     ) {
-        handle.motion(data, None, event);
+        handle.motion(state, None, event);
 
-        if data.pinnacle.layout_state.pending_resize {
+        if state.pinnacle.layout_state.pending_resize {
             return;
         }
 
         // TODO: if-let chains in 1.88
-        let output = self.window.output(&data.pinnacle);
+        let output = self.window.output(&state.pinnacle);
 
         if !self.window.alive() || output.is_none() {
-            data.pinnacle
+            state
+                .pinnacle
                 .cursor_state
                 .set_cursor_image(CursorImageStatus::default_named());
-            handle.unset_grab(self, data, event.serial, event.time, true);
+            handle.unset_grab(self, state, event.serial, event.time, true);
             return;
         }
 
         let Some(output) = output else {
             unreachable!();
         };
+
+        state.pinnacle.layout_state.pending_resize = true;
 
         let delta = (event.location - self.start_data.location).to_i32_round::<i32>();
 
@@ -198,6 +202,29 @@ impl PointerGrab<State> for ResizeSurfaceGrab {
             new_window_height.clamp(min_height, max_height),
         ));
 
+        if self.window.with_state(|state| state.layout_mode.is_tiled()) {
+            let (resize_x_dir, resize_y_dir) = match self.edges.0 {
+                xdg_toplevel::ResizeEdge::Top => (ResizeDir::Ahead, ResizeDir::Behind),
+                xdg_toplevel::ResizeEdge::Bottom => (ResizeDir::Ahead, ResizeDir::Ahead),
+                xdg_toplevel::ResizeEdge::Left => (ResizeDir::Behind, ResizeDir::Ahead),
+                xdg_toplevel::ResizeEdge::TopLeft => (ResizeDir::Behind, ResizeDir::Behind),
+                xdg_toplevel::ResizeEdge::BottomLeft => (ResizeDir::Behind, ResizeDir::Ahead),
+                xdg_toplevel::ResizeEdge::Right => (ResizeDir::Ahead, ResizeDir::Ahead),
+                xdg_toplevel::ResizeEdge::TopRight => (ResizeDir::Ahead, ResizeDir::Behind),
+                xdg_toplevel::ResizeEdge::BottomRight => (ResizeDir::Ahead, ResizeDir::Ahead),
+                _ => (ResizeDir::Ahead, ResizeDir::Ahead),
+            };
+
+            state.resize_tile(
+                &self.window,
+                (new_window_width.max(1), new_window_height.max(1)).into(),
+                resize_x_dir,
+                resize_y_dir,
+            );
+
+            return;
+        }
+
         self.window
             .with_state_mut(|state| state.floating_size = self.last_window_size);
 
@@ -220,8 +247,6 @@ impl PointerGrab<State> for ResizeSurfaceGrab {
             }
         };
 
-        data.pinnacle.layout_state.pending_resize = true;
-
         let mut transaction_builder = TransactionBuilder::new(false, true);
         transaction_builder.add(
             &self.window,
@@ -230,9 +255,10 @@ impl PointerGrab<State> for ResizeSurfaceGrab {
             // updated size when updating the layout.
             self.initial_window_geo.loc + self.initial_window_geo.size,
             serial,
-            &data.pinnacle.loop_handle,
+            &state.pinnacle.loop_handle,
         );
-        data.pinnacle
+        state
+            .pinnacle
             .layout_state
             .pending_transactions
             .entry(output.downgrade())
@@ -374,7 +400,9 @@ impl State {
                 return;
             };
 
-            if window.with_state(|state| !state.layout_mode.is_floating()) {
+            if window.with_state(|state| {
+                !state.layout_mode.is_floating() && !state.layout_mode.is_tiled()
+            }) {
                 return;
             }
 
@@ -423,7 +451,9 @@ impl State {
             return;
         };
 
-        if window.with_state(|state| !state.layout_mode.is_floating()) {
+        if window
+            .with_state(|state| !state.layout_mode.is_floating() && !state.layout_mode.is_tiled())
+        {
             return;
         }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -12,11 +12,11 @@ use indexmap::IndexSet;
 use smithay::{
     desktop::{layer_map_for_output, utils::surface_primary_scanout_output, WindowSurface},
     output::{Output, WeakOutput},
-    utils::{Logical, Rectangle},
+    utils::{Logical, Rectangle, Size},
 };
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::warn;
-use tree::{LayoutNode, LayoutTree};
+use tree::{LayoutNode, LayoutTree, ResizeDir};
 
 use crate::{
     backend::Backend,
@@ -28,12 +28,36 @@ use crate::{
 };
 
 impl Pinnacle {
-    fn update_windows_with_geometries(
+    fn update_windows_from_tree(
         &mut self,
         output: &Output,
-        geometries: Vec<Rectangle<i32, Logical>>,
         backend: &mut Backend,
+        tree_id: u32,
+        is_resize: bool,
     ) {
+        let tree = self
+            .layout_state
+            .layout_trees
+            .get_mut(&tree_id)
+            .expect("no tree");
+
+        let (output_width, output_height) = {
+            let map = layer_map_for_output(output);
+            let zone = map.non_exclusive_zone();
+            (zone.size.w, zone.size.h)
+        };
+
+        let (geometries, nodes): (Vec<_>, Vec<_>) = tree
+            .compute_geos(output_width as u32, output_height as u32)
+            .into_iter()
+            .unzip();
+
+        let mut nodes = nodes.into_iter();
+
+        for win in self.windows.iter() {
+            win.with_state_mut(|state| state.layout_node.take());
+        }
+
         let (windows_on_foc_tags, to_unmap) = output.with_state(|state| {
             let focused_tags = state.focused_tags().cloned().collect::<IndexSet<_>>();
             self.windows
@@ -121,7 +145,17 @@ impl Pinnacle {
             geo
         }));
 
-        let wins_and_geos_tiled = zipped.by_ref().map(|(win, geo)| (win, geo, true));
+        let wins_and_geos_tiled = zipped
+            .by_ref()
+            .map(|(win, geo)| (win, geo, true))
+            .collect::<Vec<_>>();
+
+        let just_wins = wins_and_geos_tiled.iter().map(|thin| &thin.0);
+
+        for win in just_wins {
+            win.with_state_mut(|state| state.layout_node = nodes.next());
+        }
+
         let wins_and_geos_other = self
             .layout_state
             .pending_window_updates
@@ -131,6 +165,7 @@ impl Pinnacle {
             .map(|(win, geo)| (win, geo, false));
 
         let wins_and_geos = wins_and_geos_tiled
+            .into_iter()
             .chain(wins_and_geos_other)
             .collect::<Vec<_>>();
 
@@ -185,6 +220,14 @@ impl Pinnacle {
             .entry(output.downgrade())
             .or_default()
             .push(transaction_builder.into_pending(unmapping));
+
+        if is_resize {
+            self.layout_state
+                .pending_transactions
+                .entry(output.downgrade())
+                .or_default()
+                .push(TransactionBuilder::new(false, true).into_pending(Vec::new()));
+        }
 
         let (remaining_wins, _remaining_geos) = zipped.unzip::<_, _, Vec<_>, Vec<_>>();
 
@@ -449,7 +492,7 @@ impl State {
         };
 
         let tree_entry = self.pinnacle.layout_state.layout_trees.entry(tree_id);
-        let tree = match tree_entry {
+        match tree_entry {
             Entry::Occupied(occupied_entry) => {
                 let tree = occupied_entry.into_mut();
                 tree.diff(root_node);
@@ -458,19 +501,38 @@ impl State {
             Entry::Vacant(vacant_entry) => vacant_entry.insert(LayoutTree::new(root_node)),
         };
 
-        let (output_width, output_height) = {
-            let map = layer_map_for_output(&output);
-            let zone = map.non_exclusive_zone();
-            (zone.size.w, zone.size.h)
-        };
-
-        let geometries = tree.compute_geos(output_width as u32, output_height as u32);
-
         self.pinnacle
-            .update_windows_with_geometries(&output, geometries, &mut self.backend);
+            .update_windows_from_tree(&output, &mut self.backend, tree_id, false);
 
         self.schedule_render(&output);
 
         Ok(())
+    }
+
+    /// Resizes the tile corresponding to the given tiled window to the new size.
+    ///
+    /// If the window is not tiled, does nothing.
+    ///
+    /// Will resize in the provided directions.
+    pub fn resize_tile(
+        &mut self,
+        window: &WindowElement,
+        new_size: Size<i32, Logical>,
+        resize_x_dir: ResizeDir,
+        resize_y_dir: ResizeDir,
+    ) {
+        let Some(output) = window.output(&self.pinnacle) else {
+            return;
+        };
+
+        let Some(node) = window.with_state(|state| state.layout_node) else {
+            return;
+        };
+
+        let tree = self.pinnacle.layout_state.layout_trees.get_mut(&0).unwrap();
+        tree.resize_tile(node, new_size, resize_x_dir, resize_y_dir);
+
+        self.pinnacle
+            .update_windows_from_tree(&output, &mut self.backend, 0, true);
     }
 }

--- a/src/window/window_state.rs
+++ b/src/window/window_state.rs
@@ -336,6 +336,8 @@ pub struct WindowElementState {
     pub floating_size: Size<i32, Logical>,
 
     pub pending_transactions: Vec<(Serial, Transaction)>,
+
+    pub layout_node: Option<taffy::NodeId>,
 }
 
 impl WindowElement {
@@ -588,6 +590,7 @@ impl WindowElementState {
             mapped_hook_id: None,
             decoration_mode: None,
             pending_transactions: Default::default(),
+            layout_node: None,
         }
     }
 


### PR DESCRIPTION
This PR enables resizing tiles with the already-existing resize action along with drags on client-exposed resize points. This is something I've been missing while using Awesome, especially on my smaller monitors.

Todos:
- [ ] Label necessary layout nodes in builtin layout generators to allow the diff algorithm to properly track resizes
- [ ] Differ layout trees by ID in the `Cycle` generator for the reason above
- [ ] Perhaps augment `WindowHandle::set_geometry` or add `WindowHandle::set_tiled_size` to allow programmatic size changes of tiled windows
- [ ] Add an action to reset sizes back to the default
- [ ] Perf-checking and code cleanup
- [ ] TESTS. PLEASE TESTS. Preferably something like `proptest` or something similar