### PR TITLE
Improve focus handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,8 @@
 Testing
 - Test layout mode changing and how it interacts with client fullscreen/maximized requests
     - Gonna need a test client for that
+- Test `WindowHandle::in_direction`
+- Test new output focus system
 
 Problems:
 - Pointer input to xwayland windows saturates at x=0, y=0, so windows on outputs at negative coords

--- a/src/api/render/v1.rs
+++ b/src/api/render/v1.rs
@@ -29,7 +29,7 @@ impl render::v1::render_service_server::RenderService for super::RenderService {
 
         run_unary_no_response(&self.sender, move |state| {
             state.backend.set_upscale_filter(filter);
-            for output in state.pinnacle.outputs.keys().cloned().collect::<Vec<_>>() {
+            for output in state.pinnacle.outputs.clone() {
                 state.backend.reset_buffers(&output);
                 state.schedule_render(&output);
             }
@@ -54,7 +54,7 @@ impl render::v1::render_service_server::RenderService for super::RenderService {
 
         run_unary_no_response(&self.sender, move |state| {
             state.backend.set_downscale_filter(filter);
-            for output in state.pinnacle.outputs.keys().cloned().collect::<Vec<_>>() {
+            for output in state.pinnacle.outputs.clone() {
                 state.backend.reset_buffers(&output);
                 state.schedule_render(&output);
             }

--- a/src/api/signal.rs
+++ b/src/api/signal.rs
@@ -53,6 +53,7 @@ impl SignalState {
         self.output_move.clear();
         self.window_pointer_enter.clear();
         self.window_pointer_leave.clear();
+        self.window_focused.clear();
         self.tag_active.clear();
         self.input_device_added.clear();
     }

--- a/src/api/tag.rs
+++ b/src/api/tag.rs
@@ -38,7 +38,6 @@ pub fn set_active(state: &mut State, tag: &Tag, set: Option<bool>) {
 
     state.pinnacle.request_layout(&output);
 
-    state.update_keyboard_focus(&output);
     state.schedule_render(&output);
 }
 
@@ -62,7 +61,6 @@ pub fn switch_to(state: &mut State, tag: &Tag) {
 
     state.pinnacle.request_layout(&output);
 
-    state.update_keyboard_focus(&output);
     state.schedule_render(&output);
 }
 
@@ -115,7 +113,7 @@ pub fn remove(state: &mut State, tags_to_remove: Vec<Tag>) {
         })
     }
 
-    for output in state.pinnacle.outputs.keys().cloned().collect::<Vec<_>>() {
+    for output in state.pinnacle.outputs.clone() {
         output.with_state_mut(|state| {
             for tag_to_remove in tags_to_remove.iter() {
                 state.tags.shift_remove(tag_to_remove);

--- a/src/api/tag/v1.rs
+++ b/src/api/tag/v1.rs
@@ -19,7 +19,7 @@ use crate::{
 impl v1::tag_service_server::TagService for super::TagService {
     async fn get(&self, _request: Request<GetRequest>) -> TonicResult<GetResponse> {
         run_unary(&self.sender, move |state| {
-            let tags = state.pinnacle.outputs.keys().flat_map(|op| {
+            let tags = state.pinnacle.outputs.iter().flat_map(|op| {
                 op.with_state(|state| {
                     state
                         .tags

--- a/src/api/window/v1.rs
+++ b/src/api/window/v1.rs
@@ -140,12 +140,8 @@ impl v1::window_service_server::WindowService for super::WindowService {
             let focused = window_id
                 .window(&state.pinnacle)
                 .and_then(|win| {
-                    let current_keyboard_focus = state
-                        .pinnacle
-                        .seat
-                        .get_keyboard()
-                        .unwrap()
-                        .current_focus()?;
+                    let current_keyboard_focus =
+                        state.pinnacle.seat.get_keyboard()?.current_focus()?;
 
                     Some(matches!(
                         current_keyboard_focus,

--- a/src/backend/dummy.rs
+++ b/src/backend/dummy.rs
@@ -115,7 +115,9 @@ impl Pinnacle {
 
         let global = output.create_global::<State>(&self.display_handle);
 
-        self.outputs.insert(output.clone(), Some(global));
+        output.with_state_mut(|state| state.enabled_global_id = Some(global));
+
+        self.outputs.push(output.clone());
 
         self.space.map_output(&output, loc);
 

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -185,10 +185,11 @@ impl Winit {
         let init = Box::new(move |pinnacle: &mut Pinnacle| {
             let output = winit.output.clone();
             let global = output.create_global::<State>(&display_handle);
+            output.with_state_mut(|state| state.enabled_global_id = Some(global));
 
             pinnacle.output_focus_stack.set_focus(output.clone());
 
-            pinnacle.outputs.insert(output.clone(), Some(global));
+            pinnacle.outputs.push(output.clone());
 
             pinnacle
                 .shm_state

--- a/src/config.rs
+++ b/src/config.rs
@@ -330,7 +330,7 @@ impl Pinnacle {
         // Clear state
 
         debug!("Clearing tags");
-        for output in self.outputs.keys() {
+        for output in self.outputs.iter() {
             output.with_state_mut(|state| {
                 for tag in state.tags.iter() {
                     tag.make_defunct();

--- a/src/grab/move_grab.rs
+++ b/src/grab/move_grab.rs
@@ -55,7 +55,7 @@ impl PointerGrab<State> for MoveSurfaceGrab {
             return;
         }
 
-        state.pinnacle.raise_window(self.window.clone(), false);
+        state.pinnacle.raise_window(self.window.clone());
 
         let is_floating = self
             .window
@@ -68,7 +68,7 @@ impl PointerGrab<State> for MoveSurfaceGrab {
             state
                 .pinnacle
                 .space
-                .map_element(self.window.clone(), new_loc.to_i32_round(), true);
+                .map_element(self.window.clone(), new_loc.to_i32_round(), false);
 
             self.window.with_state_mut(|state| {
                 state.set_floating_loc(new_loc.to_i32_round());

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -276,7 +276,6 @@ impl CompositorHandler for State {
                         let output = window.output(&self.pinnacle);
 
                         if let Some(output) = output {
-                            self.update_keyboard_focus(&output);
                             self.pinnacle.request_layout(&output);
                         }
                     }
@@ -725,12 +724,6 @@ impl WlrLayerShellHandler for State {
         }) {
             map.unmap_layer(&layer);
             output = Some(op.clone());
-        }
-
-        let focused_output = self.pinnacle.focused_output().cloned();
-
-        if let Some(focused_output) = focused_output {
-            self.update_keyboard_focus(&focused_output);
         }
 
         if let Some(output) = output {

--- a/src/handlers/foreign_toplevel.rs
+++ b/src/handlers/foreign_toplevel.rs
@@ -21,8 +21,8 @@ impl ForeignToplevelHandler for State {
             return;
         };
 
-        output.with_state_mut(|state| state.focus_stack.set_focus(window.clone()));
-        self.pinnacle.raise_window(window.clone(), true);
+        self.pinnacle.keyboard_focus_stack.set_focus(window.clone());
+        self.pinnacle.raise_window(window.clone());
 
         if !window.is_on_active_tag() {
             let new_active_tag = window.with_state(|state| {
@@ -37,7 +37,6 @@ impl ForeignToplevelHandler for State {
                 crate::api::tag::switch_to(self, &tag);
             }
         } else {
-            self.update_keyboard_focus(&output);
             self.schedule_render(&output);
         }
     }

--- a/src/handlers/session_lock.rs
+++ b/src/handlers/session_lock.rs
@@ -2,7 +2,6 @@ use smithay::{
     delegate_session_lock,
     output::Output,
     reexports::wayland_server::protocol::wl_output::WlOutput,
-    utils::SERIAL_COUNTER,
     wayland::session_lock::{
         LockSurface, SessionLockHandler, SessionLockManagerState, SessionLocker,
     },
@@ -10,7 +9,6 @@ use smithay::{
 use tracing::{debug, warn};
 
 use crate::{
-    focus::keyboard::KeyboardFocusTarget,
     output::BlankingState,
     state::{State, WithState},
 };
@@ -132,21 +130,6 @@ impl SessionLockHandler for State {
             state.size = Some((geo.size.w as u32, geo.size.h as u32).into())
         });
         surface.send_configure();
-
-        // Only auto-focus the first received lock surface.
-        // Removes the need to click on the lock surface for gtklock to get keyboard input.
-        if let Some(keyboard) = self.pinnacle.seat.get_keyboard() {
-            if !matches!(
-                keyboard.current_focus(),
-                Some(KeyboardFocusTarget::LockSurface(_))
-            ) {
-                keyboard.set_focus(
-                    self,
-                    Some(KeyboardFocusTarget::LockSurface(surface.clone())),
-                    SERIAL_COUNTER.next_serial(),
-                );
-            }
-        }
 
         output.with_state_mut(|state| state.lock_surface.replace(surface));
 

--- a/src/handlers/xdg_activation.rs
+++ b/src/handlers/xdg_activation.rs
@@ -10,7 +10,7 @@ use smithay::{
 };
 use tracing::debug;
 
-use crate::state::{State, WithState};
+use crate::state::State;
 
 pub const XDG_ACTIVATION_TOKEN_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -89,19 +89,14 @@ impl XdgActivationHandler for State {
                 ActivationContext::FocusIfPossible => {
                     if window.is_on_active_tag() {
                         let Some(output) = window.output(&self.pinnacle) else {
-                            // TODO: make "no tags" be all tags on an output
                             debug!("xdg-activation: focus-if-possible request on window but it had no tags");
                             self.pinnacle.xdg_activation_state.remove_token(&token);
                             return;
                         };
 
-                        self.pinnacle.raise_window(window.clone(), true);
+                        self.pinnacle.raise_window(window.clone());
 
-                        output.with_state_mut(|state| {
-                            state.focus_stack.set_focus(window);
-                        });
-
-                        self.update_keyboard_focus(&output);
+                        self.pinnacle.keyboard_focus_stack.set_focus(window);
 
                         self.schedule_render(&output);
                     }

--- a/src/handlers/xwayland.rs
+++ b/src/handlers/xwayland.rs
@@ -121,8 +121,8 @@ impl XwmHandler for State {
             window.set_tags_to_output(output);
         }
 
-        self.pinnacle.space.map_element(window.clone(), loc, true);
-        self.pinnacle.raise_window(window.clone(), true);
+        self.pinnacle.space.map_element(window.clone(), loc, false);
+        self.pinnacle.raise_window(window.clone());
 
         for output in self.pinnacle.space.outputs_for_element(&window) {
             self.schedule_render(&output);
@@ -229,7 +229,7 @@ impl XwmHandler for State {
             return;
         };
 
-        self.pinnacle.space.map_element(win, geometry.loc, true);
+        self.pinnacle.space.map_element(win, geometry.loc, false);
     }
 
     fn maximize_request(&mut self, _xwm: XwmId, window: X11Surface) {
@@ -508,8 +508,6 @@ impl State {
             if should_layout {
                 self.pinnacle.request_layout(&output);
             }
-
-            self.update_keyboard_focus(&output);
         }
 
         for output in outputs {
@@ -637,7 +635,7 @@ impl Pinnacle {
 
         let new_scale = if xwayland_state.should_clients_self_scale {
             self.outputs
-                .keys()
+                .iter()
                 .map(|op| op.current_scale().fractional_scale())
                 .max_by(|a, b| a.total_cmp(b))
                 .unwrap_or(1.0)
@@ -674,7 +672,7 @@ impl Pinnacle {
             .compositor_state
             .set_client_scale(new_scale);
 
-        for output in self.outputs.keys() {
+        for output in self.outputs.iter() {
             output.change_current_state(None, None, None, None);
         }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -388,7 +388,7 @@ impl State {
     pub fn update_layout(&mut self) {
         let _span = tracy_client::span!("State::update_layout");
 
-        for output in self.pinnacle.outputs.keys().cloned().collect::<Vec<_>>() {
+        for output in self.pinnacle.outputs.clone() {
             let mut transactions = Vec::new();
 
             while let Some(tx) = self
@@ -471,11 +471,7 @@ impl State {
 
 impl Pinnacle {
     pub fn request_layout(&mut self, output: &Output) {
-        if self
-            .outputs
-            .get(output)
-            .is_some_and(|global| global.is_none())
-        {
+        if output.with_state(|state| state.enabled_global_id.is_none()) {
             return;
         }
 

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -33,7 +33,7 @@ impl TagId {
     pub fn tag(&self, pinnacle: &Pinnacle) -> Option<Tag> {
         let _span = tracy_client::span!("TagId::tag");
 
-        pinnacle.outputs.keys().find_map(|op| {
+        pinnacle.outputs.iter().find_map(|op| {
             op.with_state(|state| {
                 state
                     .tags
@@ -118,7 +118,7 @@ impl Tag {
 
         pinnacle
             .outputs
-            .keys()
+            .iter()
             .find(|output| output.with_state(|state| state.tags.contains(self)))
             .cloned()
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -380,9 +380,7 @@ impl Pinnacle {
             });
         }
 
-        for output in self.outputs.keys() {
-            output.with_state_mut(|state| state.focus_stack.remove(window));
-        }
+        self.keyboard_focus_stack.remove(window);
 
         let to_schedule = self.space.outputs_for_element(window);
         self.space.unmap_elem(window);
@@ -443,9 +441,6 @@ impl Pinnacle {
 
             if tag_output != overlapping_output {
                 win.set_tags_to_output(&overlapping_output);
-
-                tag_output.with_state_mut(|state| state.focus_stack.remove(win));
-                overlapping_output.with_state_mut(|state| state.focus_stack.set_focus(win.clone()));
             }
         }
     }
@@ -487,8 +482,7 @@ impl State {
 
         self.pinnacle.windows.push(window.clone());
 
-        self.pinnacle
-            .raise_window(window.clone(), window.is_on_active_tag());
+        self.pinnacle.raise_window(window.clone());
 
         if attempt_float_on_map && should_float(&window) {
             window.with_state_mut(|state| {
@@ -511,10 +505,9 @@ impl State {
         // TODO: xdg activation
 
         if focus {
-            output.with_state_mut(|state| state.focus_stack.set_focus(window.clone()));
-            self.update_keyboard_focus(&output);
+            self.pinnacle.keyboard_focus_stack.set_focus(window);
         } else {
-            output.with_state_mut(|state| state.focus_stack.add_focus(window.clone()));
+            self.pinnacle.keyboard_focus_stack.add_focus(window);
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -71,8 +71,8 @@ pub async fn test_api(test: fn(&StateSender, Lang) -> anyhow::Result<()>) -> any
         }
     };
 
-    test_with_lang(test, Lang::Lua)?;
     test_with_lang(test, Lang::Rust)?;
+    test_with_lang(test, Lang::Lua)?;
 
     Ok(())
 }
@@ -137,7 +137,7 @@ fn test_with_lang(
     event_loop.run(Duration::from_secs(1), &mut state, |state| {
         state.on_event_loop_cycle_completion();
 
-        for output in state.pinnacle.outputs.keys() {
+        for output in state.pinnacle.outputs.iter() {
             for window in state.pinnacle.space.elements_for_output(output) {
                 window.send_frame(
                     output,

--- a/wlcs_pinnacle/src/main_loop.rs
+++ b/wlcs_pinnacle/src/main_loop.rs
@@ -87,7 +87,7 @@ pub(crate) fn run(channel: Channel<WlcsEvent>) {
             // Because nothing is actually rendering it's hard to use `send_frame_callbacks`
             // because the surface doesn't have a primary scanout output, because *that* needs
             // actual rendering to happen. So we just send frames here.
-            let output = state.pinnacle.outputs.keys().next().cloned().unwrap();
+            let output = state.pinnacle.outputs.first().cloned().unwrap();
             for window in state.pinnacle.space.elements_for_output(&output) {
                 window.send_frame(
                     &output,


### PR DESCRIPTION
Focus handling has been modified to
1. Centralize updating of keyboard focus, and
2. Decouple output focus from pointer motion.

Of course, this means moving the pointer to another output doesn't focus that output anymore (though click to focus has been added). That's where we add `OutputHandle::focus()` and an "output pointer entered/left" signal to bring back that functionality. Unfortunately, this is a breaking change.

Todos:
- [ ] `OutputHandle::focus`
- [ ] Output pointer enter/leave signal
- [ ] Enable output focus by adding `OutputHandle::in_direction`, similar to the recently added `WindowHandle::in_direction`
- [ ] Wiki: add a Focus page detailing window and output focus behavior
- [ ] Wiki: Add a breaking changes/migration page for old -> new configs

Issues:
- [ ] The pointer always starts at (0, 0), so any changes to output location that happen *before* a connection to the new output pointer enter signal mean that signal won't trigger, so the focused output may not be the one the pointer is on at startup. That's a little sharp corner to figure out.
    - Could warp the pointer relative to its output when it moves

Will close #319 