### PR TITLE
justfile: Fix various error when building from source

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,7 +34,6 @@ install-lua-lib: gen-lua-pb-defs
 clean: clean-snowcap
     rm -rf "{{xdg_data_dir}}"
     -luarocks remove --local pinnacle-api
-    -luarocks remove --local lua-grpc-client
 
 # Run `cargo build`
 build *args: gen-lua-pb-defs

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ install-protos:
 install-lua-lib: gen-lua-pb-defs
     #!/usr/bin/env bash
     cd "{{rootdir}}/api/lua"
-    luarocks make --local --lua-version "{{lua_version}}" pinnacle-api-dev-1.rockspec
+    luarocks make --local --deps-mode "order" --lua-version "{{lua_version}}" pinnacle-api-dev-1.rockspec
 
 # Remove installed configs and the Lua API (requires Luarocks)
 clean: clean-snowcap

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ lua_version := "5.4"
 
 local_lua_path := x"$HOME/.luarocks/share/lua/" + lua_version + x"/?.lua;$HOME/.luarocks/share/lua/" + lua_version + "/?.init.lua;"
 export LUA_PATH := local_lua_path + env("LUA_PATH", "")
-export LUA_CPATH := x"$HOME/.luarocks/lib/lua/" + lua_version + x"/?.so;$LUA_CPATH"
+export LUA_CPATH := x"$HOME/.luarocks/lib/lua/" + lua_version + x"/?.so;" + env("LUA_CPATH", "")
 
 list:
     @just --list --unsorted

--- a/justfile
+++ b/justfile
@@ -5,9 +5,24 @@ xdg_data_dir := `echo "${XDG_DATA_HOME:-$HOME/.local/share}/pinnacle"`
 
 lua_version := "5.4"
 
+# dirty trick until just's which() is stabilized.
+luarocks := `which luarocks 2>/dev/null || true`
+luarocks_full := if luarocks != "" { `luarocks path --help | grep -- "--full " || true`  } else { "" }
+
 local_lua_path := x"$HOME/.luarocks/share/lua/" + lua_version + x"/?.lua;$HOME/.luarocks/share/lua/" + lua_version + "/?.init.lua;"
-export LUA_PATH := local_lua_path + env("LUA_PATH", "")
-export LUA_CPATH := x"$HOME/.luarocks/lib/lua/" + lua_version + x"/?.so;" + env("LUA_CPATH", "")
+local_lua_cpath := x"$HOME/.luarocks/lib/lua/" + lua_version + x"/?.so;"
+
+export LUA_PATH := if luarocks_full != "" {
+    shell(luarocks + ' "$@"', 'path', '--full', '--lr-path', '--lua-version', lua_version)
+} else if luarocks != "" {
+    shell(luarocks + ' "$@"', 'path', '--lr-path', '--lua-version', lua_version) + ";" + env("LUA_PATH", "")
+} else { local_lua_path + env("LUA_PATH", "") }
+
+export LUA_CPATH := if luarocks_full != "" {
+    shell(luarocks + ' "$@"', 'path', '--full', '--lr-cpath', '--lua-version', lua_version)
+} else if luarocks != "" {
+    shell(luarocks + ' "$@"', 'path', '--lr-cpath', '--lua-version', lua_version) + ";" + env("LUA_CPATH", "")
+} else { local_lua_cpath + env("LUA_CPATH", "") }
 
 list:
     @just --list --unsorted

--- a/snowcap/justfile
+++ b/snowcap/justfile
@@ -21,7 +21,6 @@ install-protos:
 clean:
     rm -rf "{{xdg_data_dir}}"
     -luarocks remove --local snowcap-api
-    -luarocks remove --local lua-grpc-client
 
 # Generate the protobuf definitions Lua file
 gen-lua-pb-defs:


### PR DESCRIPTION
This PR fixes various issue I encountered while building from main.
- `just` invocation failed if started without `LUA_CPATH` in the environment
- `just install` failed due some dependencies failing to build
- `just clean` complains about trying to remove `lua-grpc-client` even though the rock no longer exists

> `just install` failed due some dependencies failing to build

This is outside of pinnacle control. `luaossl`, a dependency of `http`, fails to build on recent compilers due to some breaking changes in recent C syntax.
However, the way luarocks is invoked did not allow to search for dependencies in the system wide tree, so I changed the behavior.

The last commit of the series could be removed. I uses luarocks to retrieve the paths when available, instead of depending on a hardcoded string + LUA_{C,}PATH, which already does the correct thing  