### PR TITLE
luaapi: improve custom searcher logic

### DIFF
--- a/api/lua/pinnacle.lua
+++ b/api/lua/pinnacle.lua
@@ -31,6 +31,9 @@ end
 -- Insert before the actual package.path searcher so it takes priority
 table.insert(package.searchers, 1, custom_searcher)
 
+-- If luarocks.loader exists, we load it now if it wasn't already done.
+pcall(require, "luarocks.loader")
+
 local log = require("pinnacle.log")
 local client = require("pinnacle.grpc.client").client
 


### PR DESCRIPTION
The custom searcher in pinnacle.lua expect the path_searcher to exist with index 2, which is not guaranteed.

As an example if the config uses luarocks.loader instead of editing the environment, the loader will prepend itself to the searcher list, which offset everything, so the custom searcher will now call preload_searcher instead.

This PR fixes that issue by iterating over all existing loaders.

The second commit additionally requires `luarocks.loader`, but in a pcall to prevent a crash if luarocks.loader does not exists. 
Currently, it's called after the loader setup, which might not be the best place.

@Ottatop this means that `snowcap` might be searched first in `luarocks.loader` (in case it wasn't added to the default config), which will fail as long as `snowcap` doesn't exist as a standalone module. However this has no functional impact until snowcap become standalone, so I'm not sure it really matter.

I'm fine with dropping the second commit if you don't want it, or moving the require above the custom_search, but since there's no way of knowing ahead of time if another custom loader gets registered, I'm not sure it really matter.