### PR TITLE
layout: Update window floating loc on resize

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -453,6 +453,7 @@ impl State {
                                 loc.y += initial_geo.size.h - window.geometry().size.h;
                             }
 
+                            window.with_state_mut(|s| s.set_floating_loc(loc));
                             loc
                         }
                     };


### PR DESCRIPTION
The window have two 'properties' when it come to their location. One is the surface location (i.e. where the surface is mapped in global space), the other is the floating location (used to restore the surface when switching to a floating mode).

Only the surface location was updated on a resize previously.

fixes: #332  