### PR TITLE
snowcap: Size layers based on the widget

### DIFF
--- a/api/lua/pinnacle/snowcap.lua
+++ b/api/lua/pinnacle/snowcap.lua
@@ -73,8 +73,8 @@ function QuitPrompt:view()
     quit_font.weight = Widget.font.weight.BOLD
 
     local prompt = Widget.container({
-        width = Widget.length.Fill,
-        height = Widget.length.Fill,
+        width = Widget.length.Fixed(self.width),
+        height = Widget.length.Fixed(self.height),
         valign = Widget.alignment.CENTER,
         halign = Widget.alignment.CENTER,
         style = {
@@ -121,8 +121,6 @@ function QuitPrompt:show()
     local Layer = require("snowcap.layer")
     local prompt = Layer.new_widget({
         program = self,
-        width = self.width,
-        height = self.height,
         anchor = nil,
         keyboard_interactivity = Layer.keyboard_interactivity.EXCLUSIVE,
         exclusive_zone = "respect",
@@ -484,8 +482,8 @@ function BindOverlay:view()
                 scrollable,
             },
         }),
-        width = Widget.length.Fill,
-        height = Widget.length.Fill,
+        width = Widget.length.Fixed(self.width),
+        height = Widget.length.Fixed(self.height),
         padding = {
             top = self.border_thickness + 10.0,
             left = self.border_thickness + 10.0,
@@ -519,8 +517,6 @@ function BindOverlay:show()
 
     local overlay = Layer.new_widget({
         program = self,
-        width = self.width,
-        height = self.height,
         anchor = nil,
         keyboard_interactivity = Layer.keyboard_interactivity.EXCLUSIVE,
         exclusive_zone = "respect",

--- a/api/rust/src/snowcap.rs
+++ b/api/rust/src/snowcap.rs
@@ -61,8 +61,8 @@ impl Program for QuitPrompt {
                 .style(text::Style::new().font(self.font.clone()).pixels(14.0))
                 .into(),
         ]))
-        .width(Length::Fill)
-        .height(Length::Fill)
+        .width(Length::Fixed(self.width as f32))
+        .height(Length::Fixed(self.height as f32))
         .vertical_alignment(Alignment::Center)
         .horizontal_alignment(Alignment::Center)
         .style(snowcap_api::widget::container::Style {
@@ -95,12 +95,8 @@ impl QuitPrompt {
 
     /// Shows this quit prompt.
     pub fn show(self) {
-        let width = self.width;
-        let height = self.height;
         snowcap_api::layer::new_widget(
             self,
-            width,
-            height,
             None,
             KeyboardInteractivity::Exclusive,
             ExclusiveZone::Respect,
@@ -369,8 +365,8 @@ impl Program for BindOverlay {
             Text::new("").style(text::Style::new().pixels(8.0)).into(), // Spacing
             scrollable.into(),
         ]))
-        .width(Length::Fill)
-        .height(Length::Fill)
+        .width(Length::Fixed(self.width as f32))
+        .height(Length::Fixed(self.height as f32))
         .padding(Padding {
             top: self.border_thickness + 10.0,
             right: self.border_thickness + 10.0,
@@ -411,12 +407,8 @@ impl BindOverlay {
 
     /// Shows this bind overlay.
     pub fn show(self) {
-        let width = self.width;
-        let height = self.height;
         snowcap_api::layer::new_widget(
             self,
-            width,
-            height,
             None,
             KeyboardInteractivity::Exclusive,
             ExclusiveZone::Respect,
@@ -512,8 +504,8 @@ impl Program for ConfigCrashedMessage {
             .style(text::Style::new().font(self.font.clone()).pixels(14.0))
             .into(),
         ]))
-        .width(Length::Fill)
-        .height(Length::Fill)
+        .width(Length::Fixed(self.width as f32))
+        .height(Length::Fixed(self.height as f32))
         .padding(Padding {
             top: 16.0,
             right: 16.0,
@@ -553,12 +545,8 @@ impl ConfigCrashedMessage {
 
     /// Shows an error message.
     pub fn show(self) {
-        let width = self.width;
-        let height = self.height;
         snowcap_api::layer::new_widget(
             self,
-            width,
-            height,
             None,
             KeyboardInteractivity::Exclusive,
             ExclusiveZone::Respect,

--- a/snowcap/api/lua/snowcap/grpc/defs.lua
+++ b/snowcap/api/lua/snowcap/grpc/defs.lua
@@ -922,8 +922,6 @@ local snowcap_layer_v1_Layer = {
 
 ---@class snowcap.layer.v1.NewLayerRequest
 ---@field widget_def snowcap.widget.v1.WidgetDef?
----@field width integer?
----@field height integer?
 ---@field anchor snowcap.layer.v1.Anchor?
 ---@field keyboard_interactivity snowcap.layer.v1.KeyboardInteractivity?
 ---@field exclusive_zone integer?
@@ -938,8 +936,6 @@ local snowcap_layer_v1_Layer = {
 ---@class snowcap.layer.v1.UpdateLayerRequest
 ---@field layer_id integer?
 ---@field widget_def snowcap.widget.v1.WidgetDef?
----@field width integer?
----@field height integer?
 ---@field anchor snowcap.layer.v1.Anchor?
 ---@field keyboard_interactivity snowcap.layer.v1.KeyboardInteractivity?
 ---@field exclusive_zone integer?

--- a/snowcap/api/lua/snowcap/layer.lua
+++ b/snowcap/api/lua/snowcap/layer.lua
@@ -73,8 +73,6 @@ end
 
 ---@class snowcap.layer.LayerArgs
 ---@field program snowcap.widget.Program
----@field width integer
----@field height integer
 ---@field anchor snowcap.layer.Anchor?
 ---@field keyboard_interactivity snowcap.layer.KeyboardInteractivity
 ---@field exclusive_zone snowcap.layer.ExclusiveZone
@@ -121,8 +119,6 @@ function layer.new_widget(args)
     local request = {
         layer = args.layer,
         exclusive_zone = exclusive_zone_to_api(args.exclusive_zone),
-        width = args.width,
-        height = args.height,
         anchor = args.anchor,
         keyboard_interactivity = args.keyboard_interactivity,
         widget_def = widget.widget_def_into_api(widget_def),

--- a/snowcap/api/protobuf/snowcap/layer/v1/layer.proto
+++ b/snowcap/api/protobuf/snowcap/layer/v1/layer.proto
@@ -35,12 +35,10 @@ enum Layer {
 
 message NewLayerRequest {
   snowcap.widget.v1.WidgetDef widget_def = 1;
-  uint32 width = 2;
-  uint32 height = 3;
-  Anchor anchor = 4;
-  KeyboardInteractivity keyboard_interactivity = 5;
-  int32 exclusive_zone = 6;
-  Layer layer = 7;
+  Anchor anchor = 2;
+  KeyboardInteractivity keyboard_interactivity = 3;
+  int32 exclusive_zone = 4;
+  Layer layer = 5;
 }
 
 message NewLayerResponse {
@@ -52,14 +50,12 @@ message CloseRequest {
 }
 
 message UpdateLayerRequest {
-  uint32 layer_id = 8;
-  optional snowcap.widget.v1.WidgetDef widget_def = 1;
-  optional uint32 width = 2;
-  optional uint32 height = 3;
-  optional Anchor anchor = 4;
-  optional KeyboardInteractivity keyboard_interactivity = 5;
-  optional int32 exclusive_zone = 6;
-  optional Layer layer = 7;
+  uint32 layer_id = 1;
+  optional snowcap.widget.v1.WidgetDef widget_def = 2;
+  optional Anchor anchor = 3;
+  optional KeyboardInteractivity keyboard_interactivity = 4;
+  optional int32 exclusive_zone = 5;
+  optional Layer layer = 6;
 }
 message UpdateLayerResponse {}
 

--- a/snowcap/api/rust/src/layer.rs
+++ b/snowcap/api/rust/src/layer.rs
@@ -127,8 +127,6 @@ pub enum NewLayerError {
 /// Create a new widget.
 pub fn new_widget<Msg, P>(
     mut program: P,
-    width: u32,
-    height: u32,
     anchor: Option<Anchor>,
     keyboard_interactivity: KeyboardInteractivity,
     exclusive_zone: ExclusiveZone,
@@ -151,8 +149,6 @@ where
     let response = Client::layer()
         .new_layer(NewLayerRequest {
             widget_def: Some(widget_def.clone().into()),
-            width,
-            height,
             anchor: anchor
                 .map(From::from)
                 .unwrap_or(layer::v1::Anchor::Unspecified) as i32,
@@ -194,8 +190,6 @@ where
                             .update_layer(UpdateLayerRequest {
                                 layer_id,
                                 widget_def: Some(widget_def.into()),
-                                width: None,
-                                height: None,
                                 anchor: None,
                                 keyboard_interactivity: None,
                                 exclusive_zone: None,

--- a/snowcap/src/api/layer/v0alpha1.rs
+++ b/snowcap/src/api/layer/v0alpha1.rs
@@ -34,8 +34,8 @@ impl layer_service_server::LayerService for super::LayerService {
             return Err(Status::invalid_argument("no widget def"));
         };
 
-        let width = request.width.unwrap_or(600);
-        let height = request.height.unwrap_or(480);
+        let _width = request.width.unwrap_or(600);
+        let _height = request.height.unwrap_or(480);
 
         let anchor = match anchor {
             layer::v0alpha1::Anchor::Unspecified => wlr_layer::Anchor::empty(),
@@ -86,8 +86,6 @@ impl layer_service_server::LayerService for super::LayerService {
 
             let layer = SnowcapLayer::new(
                 state,
-                width,
-                height,
                 layer,
                 anchor,
                 exclusive_zone,

--- a/snowcap/src/api/layer/v0alpha1.rs
+++ b/snowcap/src/api/layer/v0alpha1.rs
@@ -34,8 +34,8 @@ impl layer_service_server::LayerService for super::LayerService {
             return Err(Status::invalid_argument("no widget def"));
         };
 
-        let _width = request.width.unwrap_or(600);
-        let _height = request.height.unwrap_or(480);
+        let width = request.width.unwrap_or(600);
+        let height = request.height.unwrap_or(480);
 
         let anchor = match anchor {
             layer::v0alpha1::Anchor::Unspecified => wlr_layer::Anchor::empty(),
@@ -86,6 +86,7 @@ impl layer_service_server::LayerService for super::LayerService {
 
             let layer = SnowcapLayer::new(
                 state,
+                Some((width, height)),
                 layer,
                 anchor,
                 exclusive_zone,

--- a/snowcap/src/api/layer/v1.rs
+++ b/snowcap/src/api/layer/v1.rs
@@ -32,9 +32,6 @@ impl layer_service_server::LayerService for super::LayerService {
             return Err(Status::invalid_argument("no widget def"));
         };
 
-        let width = request.width;
-        let height = request.height;
-
         let anchor = match anchor {
             layer::v1::Anchor::Unspecified | layer::v1::Anchor::None => wlr_layer::Anchor::empty(),
             layer::v1::Anchor::Top => wlr_layer::Anchor::TOP,
@@ -78,8 +75,6 @@ impl layer_service_server::LayerService for super::LayerService {
 
             let layer = SnowcapLayer::new(
                 state,
-                width,
-                height,
                 layer,
                 anchor,
                 exclusive_zone,
@@ -164,24 +159,18 @@ impl layer_service_server::LayerService for super::LayerService {
 
         let widget_def = request.widget_def;
 
-        let width = request.width;
-        let height = request.height;
-
         run_unary(&self.sender, move |state| {
             let Some(layer) = state.layers.iter_mut().find(|layer| layer.layer_id == id) else {
                 return Ok(UpdateLayerResponse {});
             };
 
             layer.update_properties(
-                width,
-                height,
                 z_layer,
                 anchor,
                 exclusive_zone,
                 keyboard_interactivity,
                 widget_def.and_then(widget_def_to_fn),
                 &state.queue_handle,
-                state.compositor.as_mut().unwrap(),
             );
 
             Ok(UpdateLayerResponse {})

--- a/snowcap/src/api/layer/v1.rs
+++ b/snowcap/src/api/layer/v1.rs
@@ -75,6 +75,7 @@ impl layer_service_server::LayerService for super::LayerService {
 
             let layer = SnowcapLayer::new(
                 state,
+                None,
                 layer,
                 anchor,
                 exclusive_zone,

--- a/snowcap/src/layer.rs
+++ b/snowcap/src/layer.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU32, ptr::NonNull};
+use std::{num::NonZeroU32, ptr::NonNull, time::Instant};
 
 use iced::{Color, Size, window::RedrawRequest};
 use iced_graphics::Compositor;
@@ -53,19 +53,21 @@ impl State {
 
 pub struct SnowcapLayer {
     // SAFETY: Drop order: surface needs to be dropped before the layer
-    surface: <iced_renderer::Compositor as iced_graphics::Compositor>::Surface,
+    pub surface: <iced_renderer::Compositor as iced_graphics::Compositor>::Surface,
 
     pub layer: LayerSurface,
     pub loop_handle: LoopHandle<'static, State>,
 
     pub renderer: iced_renderer::Renderer,
 
-    pub width: u32,
-    pub height: u32,
-    pub scale: i32,
-    pub viewport: Viewport,
+    pub output_width: u32,
+    pub output_height: u32,
+    pub output_scale: i32,
+    pub pending_size: Option<(u32, u32)>,
+    pub pending_output_scale: Option<i32>,
+    pub output_viewport: Viewport,
 
-    pub redraw_requested: bool,
+    redraw_requested: bool,
     pub widgets: SnowcapWidgetProgram,
     pub clipboard: WaylandClipboard,
 
@@ -78,7 +80,14 @@ pub struct SnowcapLayer {
     pub pointer_button_sender: Option<UnboundedSender<Result<PointerButtonResponse, Status>>>,
     pub widget_event_sender: Option<UnboundedSender<(WidgetId, WidgetEvent)>>,
 
-    pub initial_configure: bool,
+    pub initial_configure: InitialConfigureState,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum InitialConfigureState {
+    PreConfigure(Option<(i32, i32)>),
+    PostConfigure,
+    PostOutputSize,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -126,8 +135,6 @@ impl HasWindowHandle for LayerWindowHandle {
 impl SnowcapLayer {
     pub fn new(
         state: &mut State,
-        width: u32,
-        height: u32,
         layer: wlr_layer::Layer,
         anchor: Anchor,
         exclusive_zone: ExclusiveZone,
@@ -143,7 +150,7 @@ impl SnowcapLayer {
             None,
         );
 
-        layer.set_size(width, height);
+        layer.set_size(1, 1);
         layer.set_anchor(anchor);
         layer.set_keyboard_interactivity(keyboard_interactivity);
         layer.set_exclusive_zone(match exclusive_zone {
@@ -181,14 +188,14 @@ impl SnowcapLayer {
 
         let mut renderer = compositor.create_renderer();
 
-        let iced_surface = compositor.create_surface(layer_window_handle, width, height);
+        let iced_surface = compositor.create_surface(layer_window_handle, 1, 1);
 
         let clipboard =
             unsafe { WaylandClipboard::new(state.conn.backend().display_ptr() as *mut _) };
 
         let next_id = state.layer_id_counter.next();
 
-        let viewport = Viewport::with_physical_size(Size::new(width, height), 1.0);
+        let viewport = Viewport::with_physical_size(Size::new(1, 1), 1.0);
 
         let widgets = SnowcapWidgetProgram::new(widgets, viewport.logical_size(), &mut renderer);
 
@@ -196,10 +203,12 @@ impl SnowcapLayer {
             surface: iced_surface,
             loop_handle: state.loop_handle.clone(),
             layer,
-            width,
-            height,
-            scale: 1,
-            viewport,
+            output_width: 1,
+            output_height: 1,
+            pending_size: None,
+            output_scale: 1,
+            pending_output_scale: None,
+            output_viewport: viewport,
             widgets,
             renderer,
             clipboard,
@@ -209,15 +218,45 @@ impl SnowcapLayer {
             keyboard_key_sender: None,
             pointer_button_sender: None,
             widget_event_sender: None,
-            initial_configure: false,
+            initial_configure: InitialConfigureState::PreConfigure(None),
             redraw_requested: false,
+        }
+    }
+
+    pub fn schedule_redraw(&mut self) {
+        if self.redraw_requested {
+            return;
+        }
+
+        self.redraw_requested = true;
+        self.widgets
+            .queue_event(iced::Event::Window(iced::window::Event::RedrawRequested(
+                Instant::now(),
+            )));
+    }
+
+    pub fn output_size_changed(
+        &mut self,
+        output_width: u32,
+        output_height: u32,
+        output_scale: i32,
+    ) {
+        if output_width == self.output_width
+            && output_height == self.output_height
+            && output_scale == self.output_scale
+        {
+            return;
+        }
+
+        self.pending_size = Some((output_width, output_height));
+
+        if output_scale != self.output_scale {
+            self.pending_output_scale = Some(output_scale);
         }
     }
 
     pub fn update_properties(
         &mut self,
-        width: Option<u32>,
-        height: Option<u32>,
         layer: Option<wlr_layer::Layer>,
         anchor: Option<Anchor>,
         exclusive_zone: Option<ExclusiveZone>,
@@ -225,18 +264,7 @@ impl SnowcapLayer {
         widgets: Option<ViewFn>,
 
         queue_handle: &QueueHandle<State>,
-        compositor: &mut crate::compositor::Compositor,
     ) {
-        if width.is_some() || height.is_some() {
-            self.width = width.unwrap_or(self.width);
-            self.height = height.unwrap_or(self.height);
-            compositor.configure_surface(
-                &mut self.surface,
-                self.width * self.scale as u32,
-                self.height * self.scale as u32,
-            );
-        }
-
         if let Some(layer) = layer {
             self.layer.set_layer(layer);
         }
@@ -258,28 +286,22 @@ impl SnowcapLayer {
                 .set_keyboard_interactivity(keyboard_interactivity);
         }
 
-        self.viewport = Viewport::with_physical_size(
-            iced::Size::new(
-                self.width * self.scale as u32,
-                self.height * self.scale as u32,
-            ),
-            self.scale as f64,
-        );
-
         if let Some(widgets) = widgets {
-            self.widgets
-                .update_view(widgets, self.viewport.logical_size(), &mut self.renderer);
+            self.widgets.update_view(
+                widgets,
+                self.output_viewport.logical_size(),
+                &mut self.renderer,
+            );
         }
 
-        self.layer
-            .wl_surface()
-            .frame(queue_handle, self.layer.wl_surface().clone());
-        self.layer.wl_surface().commit();
+        self.request_frame(queue_handle);
     }
 
-    pub fn draw(&mut self) {
-        use iced_renderer::fallback::Renderer;
-        use iced_renderer::fallback::Surface;
+    pub fn draw_if_scheduled(&mut self, compositor: &mut crate::compositor::Compositor) {
+        if !self.redraw_requested {
+            return;
+        }
+        self.redraw_requested = false;
 
         let cursor = match self.pointer_location {
             Some((x, y)) => iced::mouse::Cursor::Available(iced::Point {
@@ -289,36 +311,55 @@ impl SnowcapLayer {
             None => iced::mouse::Cursor::Unavailable,
         };
 
-        self.widgets.draw(&mut self.renderer, cursor);
+        if self.pending_output_scale.is_some() || self.pending_size.is_some() {
+            if let Some(scale) = self.pending_output_scale.take() {
+                self.output_scale = scale;
+                self.layer.wl_surface().set_buffer_scale(scale);
+            }
+            if let Some((w, h)) = self.pending_size.take() {
+                self.output_width = w;
+                self.output_height = h;
+            }
 
-        match &mut self.renderer {
-            Renderer::Primary(wgpu) => {
-                let Surface::Primary(surface) = &mut self.surface else {
-                    unreachable!();
-                };
-                iced_wgpu::window::compositor::present(
-                    wgpu,
-                    surface,
-                    &self.viewport,
-                    Color::TRANSPARENT,
-                    || {},
-                )
-                .unwrap();
-            }
-            Renderer::Secondary(skia) => {
-                let Surface::Secondary(surface) = &mut self.surface else {
-                    unreachable!();
-                };
-                iced_tiny_skia::window::compositor::present(
-                    skia,
-                    surface,
-                    &self.viewport,
-                    Color::TRANSPARENT,
-                    || {},
-                )
-                .unwrap();
-            }
+            self.output_viewport = Viewport::with_physical_size(
+                iced::Size::new(self.output_width, self.output_height),
+                self.output_scale as f64,
+            );
+
+            self.widgets
+                .rebuild_ui(self.output_viewport.logical_size(), &mut self.renderer);
+
+            self.layer
+                .set_size(self.widgets.size().width, self.widgets.size().height);
+
+            println!("CONFIGURED NEW SIZE: {:?}", self.widgets.size());
+
+            let buffer_size = self
+                .widgets
+                .viewport_scaled(self.output_scale)
+                .physical_size();
+
+            println!(
+                "buffer_size: {buffer_size:?}, scale = {}",
+                self.output_scale
+            );
+
+            compositor.configure_surface(&mut self.surface, buffer_size.width, buffer_size.height);
         }
+
+        if self.initial_configure > InitialConfigureState::PostConfigure {
+            self.widgets.draw(&mut self.renderer, cursor);
+        }
+
+        compositor
+            .present(
+                &mut self.renderer,
+                &mut self.surface,
+                &self.widgets.viewport_scaled(self.output_scale),
+                Color::TRANSPARENT,
+                || {},
+            )
+            .unwrap();
     }
 
     pub fn update(
@@ -394,25 +435,18 @@ impl SnowcapLayer {
             }
 
             self.widgets
-                .rebuild_ui(self.viewport.logical_size(), &mut self.renderer);
+                .rebuild_ui(self.output_viewport.logical_size(), &mut self.renderer);
         }
 
         if request_frame {
-            self.layer
-                .wl_surface()
-                .frame(queue_handle, self.layer.wl_surface().clone());
-            self.layer.wl_surface().commit();
+            self.request_frame(queue_handle);
         }
     }
 
-    pub fn set_scale(&mut self, scale: i32, compositor: &mut crate::compositor::Compositor) {
-        self.scale = scale;
-        self.layer.wl_surface().set_buffer_scale(scale);
-
-        compositor.configure_surface(
-            &mut self.surface,
-            self.width * scale as u32,
-            self.height * scale as u32,
-        );
+    pub fn request_frame(&self, queue_handle: &QueueHandle<State>) {
+        self.layer
+            .wl_surface()
+            .frame(queue_handle, self.layer.wl_surface().clone());
+        self.layer.wl_surface().commit();
     }
 }

--- a/snowcap/src/lib.rs
+++ b/snowcap/src/lib.rs
@@ -92,10 +92,7 @@ pub fn start(stop_signal_sender: Option<tokio::sync::oneshot::Sender<SnowcapHand
                     layer.update(&state.queue_handle, &mut state.runtime);
                 }
 
-                if layer.redraw_requested {
-                    layer.redraw_requested = false;
-                    layer.draw();
-                }
+                layer.draw_if_scheduled(state.compositor.as_mut().unwrap());
             }
         })
         .unwrap();

--- a/snowcap/src/wgpu.rs
+++ b/snowcap/src/wgpu.rs
@@ -126,7 +126,7 @@ impl iced_graphics::Compositor for Compositor {
             width,
             height,
             present_mode: iced_wgpu::wgpu::PresentMode::Mailbox,
-            desired_maximum_frame_latency: 1,
+            desired_maximum_frame_latency: 2,
             alpha_mode: iced_wgpu::wgpu::CompositeAlphaMode::PreMultiplied,
             view_formats: vec![iced_wgpu::wgpu::TextureFormat::Rgba8UnormSrgb],
         };

--- a/snowcap/src/widget.rs
+++ b/snowcap/src/widget.rs
@@ -69,11 +69,14 @@ impl SnowcapWidgetProgram {
         self.size
     }
 
-    pub fn rebuild_ui(&mut self, bounds: iced::Size, renderer: &mut iced_renderer::Renderer) {
+    pub fn rebuild_ui(&mut self, bounds: iced::Size<u32>, renderer: &mut iced_renderer::Renderer) {
         let cache = self.user_interface.take().unwrap().into_cache();
         let view = (self.view)();
         let mut tree = iced_wgpu::core::widget::Tree::empty();
         tree.diff(&view);
+
+        let bounds = iced::Size::new(bounds.width as f32, bounds.height as f32);
+
         let node =
             view.as_widget()
                 .layout(&mut tree, renderer, &Limits::new(iced::Size::ZERO, bounds));
@@ -114,7 +117,7 @@ impl SnowcapWidgetProgram {
     pub fn update_view(
         &mut self,
         new_view: ViewFn,
-        bounds: iced::Size,
+        bounds: iced::Size<u32>,
         renderer: &mut iced_renderer::Renderer,
     ) {
         self.view = new_view;

--- a/snowcap/src/widget.rs
+++ b/snowcap/src/widget.rs
@@ -70,7 +70,6 @@ impl SnowcapWidgetProgram {
     }
 
     pub fn rebuild_ui(&mut self, bounds: iced::Size, renderer: &mut iced_renderer::Renderer) {
-        println!("rebuilding ui, bounds = {bounds:?}");
         let cache = self.user_interface.take().unwrap().into_cache();
         let view = (self.view)();
         let mut tree = iced_wgpu::core::widget::Tree::empty();
@@ -134,12 +133,10 @@ impl SnowcapWidgetProgram {
         !self.queued_events.is_empty()
     }
 
-    pub fn viewport(&self, scale: i32) -> Viewport {
-        Viewport::with_physical_size(self.size, scale as f64)
-    }
-
-    pub fn viewport_scaled(&self, scale: i32) -> Viewport {
-        Viewport::with_physical_size(self.size * scale as u32, scale as f64)
+    pub fn viewport(&self, scale: f32) -> Viewport {
+        let buffer_width = (self.size.width as f32 * scale).ceil() as u32;
+        let buffer_height = (self.size.height as f32 * scale).ceil() as u32;
+        Viewport::with_physical_size(iced::Size::new(buffer_width, buffer_height), scale as f64)
     }
 }
 


### PR DESCRIPTION
This PR changes the way Snowcap layer surfaces are sized. Previously, they had a fixed size set at the time of creation. Now, layers will size based on the widget they hold. That is, a widget with `Length::Fill` will fill the whole output, and one with `Length::Shrink` will shrink as much as possible. For the previous fixed behavior, the root widget should be `Length::Fixed(size)`.

Additionally, if the output scale increases enough to make the layer too big, it will now resize downwards to fit.

Todos:
- [x] Fractional scale
    - The size of a widget is bound by the logical size of the output it's on. Right now, with integer scale, this means that a widget on an output with a scale of 1.5 thinks it's on a smaller output than it actually is. We need fractional scale to fix this.