### PR TITLE
api: add [in]active tags filtering to OutputHandle

### DIFF
--- a/api/lua/pinnacle/output.lua
+++ b/api/lua/pinnacle/output.lua
@@ -756,6 +756,62 @@ function OutputHandle:tags()
     return handles
 end
 
+---Gets the active tags this output has.
+---
+---@return pinnacle.tag.TagHandle[]
+function OutputHandle:active_tags()
+    local tags = self:tags()
+
+    ---@type (fun(): boolean)[]
+    local batch = {}
+    for i, tag in ipairs(tags) do
+        batch[i] = function()
+            return tag:active()
+        end
+    end
+
+    local responses = require("pinnacle.util").batch(batch)
+
+    ---@type pinnacle.tag.TagHandle[]
+    local active_tags = {}
+
+    for i, is_active in ipairs(responses) do
+        if is_active then
+            table.insert(active_tags, tags[i])
+        end
+    end
+
+    return active_tags
+end
+
+---Gets the inactive tags this output has.
+---
+---@return pinnacle.tag.TagHandle[]
+function OutputHandle:inactive_tags()
+    local tags = self:tags()
+
+    ---@type (fun(): boolean)[]
+    local batch = {}
+    for i, tag in ipairs(tags) do
+        batch[i] = function()
+            return not tag:active()
+        end
+    end
+
+    local responses = require("pinnacle.util").batch(batch)
+
+    ---@type pinnacle.tag.TagHandle[]
+    local inactive_tags = {}
+
+    for i, is_active in ipairs(responses) do
+        if is_active then
+            table.insert(inactive_tags, tags[i])
+        end
+    end
+
+    return inactive_tags
+end
+
 ---Get this output's scale.
 ---
 ---@return number

--- a/api/rust/src/output.rs
+++ b/api/rust/src/output.rs
@@ -856,6 +856,30 @@ impl OutputHandle {
             .map(|id| TagHandle { id })
     }
 
+    /// Gets handles to all active tags on this output.
+    pub fn active_tags(&self) -> impl Iterator<Item = TagHandle> + use<> {
+        self.active_tags_async().block_on_tokio()
+    }
+
+    /// Async impl for [`Self::active_tags`].
+    pub async fn active_tags_async(&self) -> impl Iterator<Item = TagHandle> + use<> {
+        self.tags_async()
+            .await
+            .batch_filter(|tag| tag.active_async().boxed(), |is_active| is_active)
+    }
+
+    /// Gets handles to all inactive tags on this output.
+    pub fn inactive_tags(&self) -> impl Iterator<Item = TagHandle> + use<> {
+        self.inactive_tags_async().block_on_tokio()
+    }
+
+    /// Async impl for [`Self::active_tags`].
+    pub async fn inactive_tags_async(&self) -> impl Iterator<Item = TagHandle> + use<> {
+        self.tags_async()
+            .await
+            .batch_filter(|tag| tag.active_async().boxed(), |is_active| !is_active)
+    }
+
     /// Gets this output's current scale.
     pub fn scale(&self) -> f32 {
         self.scale_async().block_on_tokio()


### PR DESCRIPTION
This PR adds part of #324 to the API, namely the OutputHandle::active_tags method.

Since protobuf allows to add new field in a backward compatible way, I've just added a filter argument.
The filter argument is setup to fallback on the 'All' filter, so client/config built for the previous API will still behave as expected.

The client/config facing api gets an additional `active_tag` method, and I've added an inactive method as well.