### PR TITLE
api/window: add response to WindowHandle::MoveToOutput RPC

### DIFF
--- a/api/lua/pinnacle/grpc/defs.lua
+++ b/api/lua/pinnacle/grpc/defs.lua
@@ -1201,6 +1201,8 @@ local pinnacle_window_v1_DecorationMode = {
 ---@field window_id integer?
 ---@field output_name string?
 
+---@class pinnacle.window.v1.MoveToOutputResponse
+
 ---@class pinnacle.window.v1.RaiseRequest
 ---@field window_id integer?
 
@@ -1430,6 +1432,7 @@ pinnacle.window.v1.SetTagRequest = {}
 pinnacle.window.v1.SetTagsRequest = {}
 pinnacle.window.v1.SetTagsResponse = {}
 pinnacle.window.v1.MoveToOutputRequest = {}
+pinnacle.window.v1.MoveToOutputResponse = {}
 pinnacle.window.v1.RaiseRequest = {}
 pinnacle.window.v1.MoveGrabRequest = {}
 pinnacle.window.v1.ResizeGrabRequest = {}
@@ -3200,7 +3203,7 @@ pinnacle.window.v1.WindowService.MoveToOutput = {}
 pinnacle.window.v1.WindowService.MoveToOutput.service = "pinnacle.window.v1.WindowService"
 pinnacle.window.v1.WindowService.MoveToOutput.method = "MoveToOutput"
 pinnacle.window.v1.WindowService.MoveToOutput.request = ".pinnacle.window.v1.MoveToOutputRequest"
-pinnacle.window.v1.WindowService.MoveToOutput.response = ".google.protobuf.Empty"
+pinnacle.window.v1.WindowService.MoveToOutput.response = ".pinnacle.window.v1.MoveToOutputResponse"
 
 ---Performs a unary request.
 ---
@@ -3208,7 +3211,7 @@ pinnacle.window.v1.WindowService.MoveToOutput.response = ".google.protobuf.Empty
 ---
 ---@param data pinnacle.window.v1.MoveToOutputRequest
 ---
----@return google.protobuf.Empty | nil response
+---@return pinnacle.window.v1.MoveToOutputResponse | nil response
 ---@return string | nil error An error string, if any
 function Client:pinnacle_window_v1_WindowService_MoveToOutput(data)
     return self:unary_request(pinnacle.window.v1.WindowService.MoveToOutput, data)

--- a/api/protobuf/pinnacle/window/v1/window.proto
+++ b/api/protobuf/pinnacle/window/v1/window.proto
@@ -152,6 +152,7 @@ message MoveToOutputRequest {
   uint32 window_id = 1;
   string output_name = 2;
 }
+message MoveToOutputResponse {}
 
 message RaiseRequest {
   uint32 window_id = 1;
@@ -215,7 +216,7 @@ service WindowService {
   rpc SetTag(SetTagRequest) returns (google.protobuf.Empty);
   // Sets the exact tags of this window.
   rpc SetTags(SetTagsRequest) returns (SetTagsResponse);
-  rpc MoveToOutput(MoveToOutputRequest) returns (google.protobuf.Empty);
+  rpc MoveToOutput(MoveToOutputRequest) returns (MoveToOutputResponse);
   rpc Raise(RaiseRequest) returns (google.protobuf.Empty);
   rpc MoveGrab(MoveGrabRequest) returns (google.protobuf.Empty);
   rpc ResizeGrab(ResizeGrabRequest) returns (google.protobuf.Empty);

--- a/src/api/window/v1.rs
+++ b/src/api/window/v1.rs
@@ -14,10 +14,11 @@ use pinnacle_api_defs::pinnacle::{
             GetLocResponse, GetRequest, GetResponse, GetSizeRequest, GetSizeResponse,
             GetTagIdsRequest, GetTagIdsResponse, GetTitleRequest, GetTitleResponse,
             GetWindowsInDirRequest, GetWindowsInDirResponse, MoveGrabRequest, MoveToOutputRequest,
-            MoveToTagRequest, RaiseRequest, ResizeGrabRequest, ResizeTileRequest,
-            SetDecorationModeRequest, SetFloatingRequest, SetFocusedRequest, SetFullscreenRequest,
-            SetGeometryRequest, SetMaximizedRequest, SetTagRequest, SetTagsRequest,
-            SetTagsResponse, SwapRequest, SwapResponse, WindowRuleRequest, WindowRuleResponse,
+            MoveToOutputResponse, MoveToTagRequest, RaiseRequest, ResizeGrabRequest,
+            ResizeTileRequest, SetDecorationModeRequest, SetFloatingRequest, SetFocusedRequest,
+            SetFullscreenRequest, SetGeometryRequest, SetMaximizedRequest, SetTagRequest,
+            SetTagsRequest, SetTagsResponse, SwapRequest, SwapResponse, WindowRuleRequest,
+            WindowRuleResponse,
         },
     },
 };
@@ -671,12 +672,15 @@ impl v1::window_service_server::WindowService for super::WindowService {
         .await
     }
 
-    async fn move_to_output(&self, request: Request<MoveToOutputRequest>) -> TonicResult<()> {
+    async fn move_to_output(
+        &self,
+        request: Request<MoveToOutputRequest>,
+    ) -> TonicResult<MoveToOutputResponse> {
         let request = request.into_inner();
         let window_id = WindowId(request.window_id);
         let output_name = OutputName(request.output_name);
 
-        run_unary_no_response(&self.sender, move |state| {
+        run_unary(&self.sender, move |state| {
             if let Some(output) = output_name.output(&state.pinnacle) {
                 if let Some(window) = window_id.window(&state.pinnacle) {
                     state.move_window_to_output(&window, output);
@@ -688,6 +692,8 @@ impl v1::window_service_server::WindowService for super::WindowService {
                     }
                 }
             }
+
+            Ok(MoveToOutputResponse {})
         })
         .await
     }


### PR DESCRIPTION
As mentioned in #340, this adds a typed response to window::MoveToOutput RPC