### PR TITLE
Add WindowHandle::lower

### DIFF
--- a/api/lua/pinnacle/grpc/defs.lua
+++ b/api/lua/pinnacle/grpc/defs.lua
@@ -1206,6 +1206,11 @@ local pinnacle_window_v1_DecorationMode = {
 ---@class pinnacle.window.v1.RaiseRequest
 ---@field window_id integer?
 
+---@class pinnacle.window.v1.LowerRequest
+---@field window_id integer?
+
+---@class pinnacle.window.v1.LowerResponse
+
 ---@class pinnacle.window.v1.MoveGrabRequest
 ---@field button integer?
 
@@ -1434,6 +1439,8 @@ pinnacle.window.v1.SetTagsResponse = {}
 pinnacle.window.v1.MoveToOutputRequest = {}
 pinnacle.window.v1.MoveToOutputResponse = {}
 pinnacle.window.v1.RaiseRequest = {}
+pinnacle.window.v1.LowerRequest = {}
+pinnacle.window.v1.LowerResponse = {}
 pinnacle.window.v1.MoveGrabRequest = {}
 pinnacle.window.v1.ResizeGrabRequest = {}
 pinnacle.window.v1.SwapRequest = {}
@@ -3232,6 +3239,23 @@ pinnacle.window.v1.WindowService.Raise.response = ".google.protobuf.Empty"
 ---@return string | nil error An error string, if any
 function Client:pinnacle_window_v1_WindowService_Raise(data)
     return self:unary_request(pinnacle.window.v1.WindowService.Raise, data)
+end
+pinnacle.window.v1.WindowService.Lower = {}
+pinnacle.window.v1.WindowService.Lower.service = "pinnacle.window.v1.WindowService"
+pinnacle.window.v1.WindowService.Lower.method = "Lower"
+pinnacle.window.v1.WindowService.Lower.request = ".pinnacle.window.v1.LowerRequest"
+pinnacle.window.v1.WindowService.Lower.response = ".pinnacle.window.v1.LowerResponse"
+
+---Performs a unary request.
+---
+---@nodiscard
+---
+---@param data pinnacle.window.v1.LowerRequest
+---
+---@return pinnacle.window.v1.LowerResponse | nil response
+---@return string | nil error An error string, if any
+function Client:pinnacle_window_v1_WindowService_Lower(data)
+    return self:unary_request(pinnacle.window.v1.WindowService.Lower, data)
 end
 pinnacle.window.v1.WindowService.MoveGrab = {}
 pinnacle.window.v1.WindowService.MoveGrab.service = "pinnacle.window.v1.WindowService"

--- a/api/lua/pinnacle/window.lua
+++ b/api/lua/pinnacle/window.lua
@@ -562,6 +562,17 @@ function WindowHandle:raise()
     end
 end
 
+---Lowers a window.
+---
+---This will bring the window to the back.
+function WindowHandle:lower()
+    local _, err = client:pinnacle_window_v1_WindowService_Lower({ window_id = self.id })
+
+    if err then
+        log.error(err)
+    end
+end
+
 ---Returns whether or not this window is on an active tag.
 ---
 ---@return boolean

--- a/api/protobuf/pinnacle/window/v1/window.proto
+++ b/api/protobuf/pinnacle/window/v1/window.proto
@@ -158,6 +158,11 @@ message RaiseRequest {
   uint32 window_id = 1;
 }
 
+message LowerRequest {
+  uint32 window_id = 1;
+}
+message LowerResponse {}
+
 message MoveGrabRequest {
   uint32 button = 1;
 }
@@ -218,6 +223,7 @@ service WindowService {
   rpc SetTags(SetTagsRequest) returns (SetTagsResponse);
   rpc MoveToOutput(MoveToOutputRequest) returns (MoveToOutputResponse);
   rpc Raise(RaiseRequest) returns (google.protobuf.Empty);
+  rpc Lower(LowerRequest) returns (LowerResponse);
   rpc MoveGrab(MoveGrabRequest) returns (google.protobuf.Empty);
   rpc ResizeGrab(ResizeGrabRequest) returns (google.protobuf.Empty);
   rpc Swap(SwapRequest) returns (SwapResponse);

--- a/api/rust/src/window.rs
+++ b/api/rust/src/window.rs
@@ -20,7 +20,7 @@ use pinnacle_api_defs::pinnacle::{
         v1::{
             GetAppIdRequest, GetFocusedRequest, GetLayoutModeRequest, GetLocRequest,
             GetSizeRequest, GetTagIdsRequest, GetTitleRequest, GetWindowsInDirRequest,
-            MoveGrabRequest, MoveToOutputRequest, MoveToTagRequest, RaiseRequest,
+            LowerRequest, MoveGrabRequest, MoveToOutputRequest, MoveToTagRequest, RaiseRequest,
             ResizeGrabRequest, ResizeTileRequest, SetDecorationModeRequest, SetFloatingRequest,
             SetFocusedRequest, SetFullscreenRequest, SetGeometryRequest, SetMaximizedRequest,
             SetTagRequest, SetTagsRequest, SwapRequest,
@@ -573,6 +573,15 @@ impl WindowHandle {
         let window_id = self.id;
         Client::window()
             .raise(RaiseRequest { window_id })
+            .block_on_tokio()
+            .unwrap();
+    }
+
+    /// Lowers this window to the back.
+    pub fn lower(&self) {
+        let window_id = self.id;
+        Client::window()
+            .lower(LowerRequest { window_id })
             .block_on_tokio()
             .unwrap();
     }

--- a/src/api/window.rs
+++ b/src/api/window.rs
@@ -231,6 +231,14 @@ pub fn raise(state: &mut State, window: WindowElement) {
     state.pinnacle.raise_window(window);
 }
 
+pub fn lower(state: &mut State, window: WindowElement) {
+    for output in state.pinnacle.space.outputs_for_element(&window) {
+        state.schedule_render(&output);
+    }
+
+    state.pinnacle.lower_window(window);
+}
+
 pub fn move_grab(state: &mut State, button: u32) {
     let Some((pointer_focus, _)) = state.pinnacle.pointer_contents.focus_under.as_ref() else {
         return;

--- a/src/api/window/v1.rs
+++ b/src/api/window/v1.rs
@@ -13,12 +13,12 @@ use pinnacle_api_defs::pinnacle::{
             GetFocusedResponse, GetLayoutModeRequest, GetLayoutModeResponse, GetLocRequest,
             GetLocResponse, GetRequest, GetResponse, GetSizeRequest, GetSizeResponse,
             GetTagIdsRequest, GetTagIdsResponse, GetTitleRequest, GetTitleResponse,
-            GetWindowsInDirRequest, GetWindowsInDirResponse, MoveGrabRequest, MoveToOutputRequest,
-            MoveToOutputResponse, MoveToTagRequest, RaiseRequest, ResizeGrabRequest,
-            ResizeTileRequest, SetDecorationModeRequest, SetFloatingRequest, SetFocusedRequest,
-            SetFullscreenRequest, SetGeometryRequest, SetMaximizedRequest, SetTagRequest,
-            SetTagsRequest, SetTagsResponse, SwapRequest, SwapResponse, WindowRuleRequest,
-            WindowRuleResponse,
+            GetWindowsInDirRequest, GetWindowsInDirResponse, LowerRequest, LowerResponse,
+            MoveGrabRequest, MoveToOutputRequest, MoveToOutputResponse, MoveToTagRequest,
+            RaiseRequest, ResizeGrabRequest, ResizeTileRequest, SetDecorationModeRequest,
+            SetFloatingRequest, SetFocusedRequest, SetFullscreenRequest, SetGeometryRequest,
+            SetMaximizedRequest, SetTagRequest, SetTagsRequest, SetTagsResponse, SwapRequest,
+            SwapResponse, WindowRuleRequest, WindowRuleResponse,
         },
     },
 };
@@ -709,6 +709,20 @@ impl v1::window_service_server::WindowService for super::WindowService {
             };
 
             crate::api::window::raise(state, window);
+        })
+        .await
+    }
+
+    async fn lower(&self, request: Request<LowerRequest>) -> TonicResult<LowerResponse> {
+        let request = request.into_inner();
+        let window_id = WindowId(request.window_id);
+
+        run_unary(&self.sender, move |state| {
+            if let Some(window) = window_id.window(&state.pinnacle) {
+                crate::api::window::lower(state, window);
+            }
+
+            Ok(LowerResponse {})
         })
         .await
     }

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -209,6 +209,23 @@ impl Pinnacle {
         self.update_xwayland_stacking_order();
     }
 
+    /// Lower a window to the bottom of the z-index stack.
+    pub fn lower_window(&mut self, window: WindowElement) {
+        let _span = tracy_client::span!("Pinnacle::lower_window");
+
+        self.z_index_stack
+            .retain(|win| !matches!(win, ZIndexElement::Window(win) if win == window));
+        self.z_index_stack.insert(0, ZIndexElement::Window(window));
+
+        for win in self.z_index_stack.iter() {
+            if let ZIndexElement::Window(win) = win {
+                self.space.raise_element(win, false);
+            }
+        }
+
+        self.update_xwayland_stacking_order();
+    }
+
     /// Get the currently focused output, or the first mapped output if there is none, or None.
     pub fn focused_output(&self) -> Option<&Output> {
         let _span = tracy_client::span!("Pinnacle::focused_output");

--- a/tests/integration/api/window.rs
+++ b/tests/integration/api/window.rs
@@ -1041,6 +1041,53 @@ fn window_handle_raise() {
 }
 
 #[test_log::test]
+fn window_handle_lower() {
+    for_each_api(|lang| {
+        let (mut fixture, _) = set_up();
+
+        let client_id = fixture.add_client();
+
+        fixture.spawn_windows(2, client_id);
+
+        let top = fixture
+            .pinnacle()
+            .z_index_stack
+            .last()
+            .unwrap()
+            .window()
+            .unwrap()
+            .clone();
+        let second = fixture.pinnacle().windows[1].clone();
+        assert_eq!(top, second);
+
+        match lang {
+            Lang::Rust => fixture.spawn_blocking(|| {
+                pinnacle_api::window::get_all()
+                    .skip(1)
+                    .next()
+                    .unwrap()
+                    .lower();
+            }),
+            Lang::Lua => spawn_lua_blocking! {
+                fixture,
+                Window.get_all()[2]:lower()
+            },
+        }
+
+        let top = fixture
+            .pinnacle()
+            .z_index_stack
+            .last()
+            .unwrap()
+            .window()
+            .unwrap()
+            .clone();
+        let first = fixture.pinnacle().windows[0].clone();
+        assert_eq!(top, first);
+    });
+}
+
+#[test_log::test]
 fn window_handle_is_on_active_tag() {
     for_each_api(|lang| {
         let (mut fixture, output) = set_up();


### PR DESCRIPTION
This PR adds a RPC to lower a window to the back.

I mentioned it in #324, when the main means of interacting with the compositor is through keyboard inputs, it's a bit tedious to switch to a lower window, since you have to basically guess where the window is. This gives tools to lower the currently focused window to the back of the Z-Buffer.

One thing I'm unsure of is whether lowering a fullscreen/maximized window make sense.
I've allowed it because in my opinion, RPCs is in the API should gives building block for configuration, not restrict whats possible as long as it does not leave the compositor in a bad state.