### PR TITLE
Add output enable/disable signal and change the current ones

### DIFF
--- a/api/lua/pinnacle/output.lua
+++ b/api/lua/pinnacle/output.lua
@@ -140,6 +140,7 @@ end
 local signal_name_to_SignalName = {
     connect = "OutputConnect",
     disconnect = "OutputDisconnect",
+    setup = "OutputSetup",
     resize = "OutputResize",
     move = "OutputMove",
     pointer_enter = "OutputPointerEnter",
@@ -148,8 +149,9 @@ local signal_name_to_SignalName = {
 }
 
 ---@class pinnacle.output.OutputSignal Signals related to output events.
----@field connect fun(output: pinnacle.output.OutputHandle)? An output was connected. FIXME: This currently does not fire for outputs that have been previously connected and disconnected.
+---@field connect fun(output: pinnacle.output.OutputHandle)? An output was connected.
 ---@field disconnect fun(output: pinnacle.output.OutputHandle)? An output was disconnected.
+---@field setup fun(output: pinnacle.output.OutputHandle)? An output was connected for the first time.
 ---@field resize fun(output: pinnacle.output.OutputHandle, logical_width: integer, logical_height: integer)? An output's logical size changed.
 ---@field move fun(output: pinnacle.output.OutputHandle, x: integer, y: integer)? An output moved.
 ---@field pointer_enter fun(output: pinnacle.output.OutputHandle)? The pointer entered an output.

--- a/api/lua/pinnacle/signal.lua
+++ b/api/lua/pinnacle/signal.lua
@@ -25,6 +25,14 @@ local signals = {
         ---@type fun(response: table)
         on_response = nil,
     },
+    OutputSetup = {
+        ---@type grpc_client.h2.Stream?
+        sender = nil,
+        ---@type { callback_id: integer, callback: fun(output: pinnacle.output.OutputHandle) }[]
+        callbacks = {},
+        ---@type fun(response: table)
+        on_response = nil,
+    },
     OutputResize = {
         ---@type grpc_client.h2.Stream?
         sender = nil,
@@ -166,6 +174,16 @@ signals.OutputDisconnect.on_response = function(response)
 
     for _, callback in ipairs(callbacks) do
         protected_callback("OutputDisconnect", callback.callback, handle)
+    end
+end
+
+signals.OutputSetup.on_response = function(response)
+    ---@diagnostic disable-next-line: invisible
+    local handle = require("pinnacle.output").handle.new(response.output_name)
+    local callbacks = require("pinnacle.util").deep_copy(signals.OutputSetup.callbacks)
+
+    for _, callback in ipairs(callbacks) do
+        protected_callback("OutputSetup", callback.callback, handle)
     end
 end
 

--- a/api/protobuf/pinnacle/signal/v1/signal.proto
+++ b/api/protobuf/pinnacle/signal/v1/signal.proto
@@ -23,6 +23,13 @@ message OutputDisconnectResponse {
   string output_name = 1;
 }
 
+message OutputSetupRequest {
+  StreamControl control = 1;
+}
+message OutputSetupResponse {
+  string output_name = 1;
+}
+
 message OutputResizeRequest {
   StreamControl control = 1;
 }
@@ -117,6 +124,7 @@ message InputDeviceAddedResponse {
 service SignalService {
   rpc OutputConnect(stream OutputConnectRequest) returns (stream OutputConnectResponse);
   rpc OutputDisconnect(stream OutputDisconnectRequest) returns (stream OutputDisconnectResponse);
+  rpc OutputSetup(stream OutputSetupRequest) returns (stream OutputSetupResponse);
   rpc OutputResize(stream OutputResizeRequest) returns (stream OutputResizeResponse);
   rpc OutputMove(stream OutputMoveRequest) returns (stream OutputMoveResponse);
   rpc OutputPointerEnter(stream OutputPointerEnterRequest) returns (stream OutputPointerEnterResponse);

--- a/api/rust/src/output.rs
+++ b/api/rust/src/output.rs
@@ -158,6 +158,7 @@ pub fn connect_signal(signal: OutputSignal) -> SignalHandle {
     match signal {
         OutputSignal::Connect(f) => signal_state.output_connect.add_callback(f),
         OutputSignal::Disconnect(f) => signal_state.output_disconnect.add_callback(f),
+        OutputSignal::Setup(f) => signal_state.output_setup.add_callback(f),
         OutputSignal::Resize(f) => signal_state.output_resize.add_callback(f),
         OutputSignal::Move(f) => signal_state.output_move.add_callback(f),
         OutputSignal::PointerEnter(f) => signal_state.output_pointer_enter.add_callback(f),

--- a/pinnacle-api-defs/src/lib.rs
+++ b/pinnacle-api-defs/src/lib.rs
@@ -64,6 +64,7 @@ pub mod pinnacle {
             impl_signal_request!(
                 OutputConnectRequest,
                 OutputDisconnectRequest,
+                OutputSetupRequest,
                 OutputResizeRequest,
                 OutputMoveRequest,
                 OutputPointerEnterRequest,

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -1069,8 +1069,10 @@ impl Udev {
             output.with_state_mut(|state| state.tags.clone_from(tags));
             pinnacle.change_output_state(self, &output, None, None, *scale, Some(*loc));
         } else {
-            pinnacle.signal_state.output_connect.signal(&output);
+            pinnacle.signal_state.output_setup.signal(&output);
         }
+
+        pinnacle.signal_state.output_connect.signal(&output);
 
         pinnacle.output_management_manager_state.update::<State>();
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -308,23 +308,17 @@ impl Pinnacle {
             self.space.map_output(output, output.current_location());
 
             // Trigger the connect signal here for configs to reposition outputs
-            //
-            // TODO: Create a new output_disable/enable signal and trigger it here
-            // instead of connect and disconnect
             if should_signal {
                 self.signal_state.output_connect.signal(output);
             }
         } else {
             if let Some(global) = output.with_state_mut(|state| state.enabled_global_id.take()) {
                 self.display_handle.remove_global::<State>(global);
+
+                // Trigger the disconnect signal here for configs to reposition outputs
+                self.signal_state.output_disconnect.signal(output);
             }
             self.space.unmap_output(output);
-
-            // Trigger the disconnect signal here for configs to reposition outputs
-            //
-            // TODO: Create a new output_disable/enable signal and trigger it here
-            // instead of connect and disconnect
-            self.signal_state.output_disconnect.signal(output);
 
             self.gamma_control_manager_state.output_removed(output);
 


### PR DESCRIPTION
This PR does two things. 
### Part 1: Changes to Output signals
It changes output signals for the api. Currently there are OutputConnect and OutputDisconnect. But these didn't really do what they should. Connect was only fired when output was connected for the first time, so there was no way to get signal when output was activated. And disconnect fired every time the monitor was switched off in any way, not just when it was actually disconnected. This fixes this behavior and adds two new signals OutputEnable and OutputDisable. 

### Part 2: Fix Silent Output Reactivation on Hotplug

This commit resolves an issue where an output could be re-enabled by the backend without firing the appropriate signals.

**Motivation:**
I was observing an issue where one of my monitors would power back on a few seconds after being disabled by an idle manager. This behavior was also present in other compositors like river and dwl, suggesting a backend or driver-level quirk that the compositor should be resilient to. Strangely enough it didn't happen in sway.

My initial attempt to fix this in my config by listening for an "enable" signal failed, as no signal was being fired when the monitor reawakened.

**Root Cause:**
Investigation revealed that this reactivation scenario bypasses the standard `set_output_enabled` and `set_output_powered` code paths. The backend handles the underlying hotplug event by calling `change_output_state` directly to apply a mode. This action physically powered on the monitor but did not update the compositor's logical state or fire the `OutputEnable` signal, leading to a desynchronization.

**Solution:**
To resolve this, the following precondition has been added to the top of `change_output_state`:

```rust
if mode.is_some() {
    self.set_output_enabled(output, true);
}
```
This change makes sure that setting a mode on an output is an explicit act of enabling it. By ensuring set_output_enabled(true) is called first, we guarantee that all code paths that physically activate a monitor are funneled through the correct signaling logic. This keeps the compositor's state consistent with the hardware and resolves the bug.
