### PR TITLE
Add powered to ConnectorSavedState

### DIFF
--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -1065,9 +1065,18 @@ impl Udev {
             .connector_saved_states
             .get(&OutputName(output.name()))
         {
-            let ConnectorSavedState { loc, tags, scale } = saved_state;
-            output.with_state_mut(|state| state.tags.clone_from(tags));
-            pinnacle.change_output_state(self, &output, None, None, *scale, Some(*loc));
+            let ConnectorSavedState {
+                loc,
+                tags,
+                scale,
+                powered,
+            } = saved_state.clone();
+
+            output.with_state_mut(|state| state.tags.clone_from(&tags));
+            pinnacle.change_output_state(self, &output, None, None, scale, Some(loc));
+            if let Some(powered) = powered {
+                self.set_output_powered(&output, &pinnacle.loop_handle, powered);
+            }
         } else {
             pinnacle.signal_state.output_connect.signal(&output);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -296,6 +296,8 @@ pub struct ConnectorSavedState {
     pub tags: IndexSet<Tag>,
     /// The output's previous scale
     pub scale: Option<smithay::output::Scale>,
+    /// The output's previous powered state
+    pub powered: Option<bool>,
     // TODO: transform
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -334,6 +334,7 @@ impl Pinnacle {
                     loc: output.current_location(),
                     tags: output.with_state(|state| state.tags.clone()),
                     scale: Some(output.current_scale()),
+                    powered: Some(output.with_state(|state| state.powered)),
                 },
             );
 
@@ -381,6 +382,7 @@ impl Pinnacle {
                 loc: output.current_location(),
                 tags: output.with_state(|state| state.tags.clone()),
                 scale: Some(output.current_scale()),
+                powered: Some(output.with_state(|state| state.powered)),
             },
         );
 


### PR DESCRIPTION
This PR introduces the powered field to `ConnectorSavedState` to correctly handle monitors that automatically try to reconnect after being powered off.

When an output is deactivated, its last known powered state is now saved. Upon reconnection, this saved state is reapplied, ensuring that an output intended to be off remains off. This resolves power-looping issues as discussed in [#362](https://github.com/pinnacle-comp/pinnacle/pull/362).

~Additionally, this change removes the creation of `ConnectorSavedState` from the `set_loc` API call. As far as I can tell there is no situation where that would be used, as it would always be overwritten by either `set_enable` or `remove_output`.~