### PR TITLE
api/lua: Fix XDG_DATA_DIRS usage.

### DIFF
--- a/api/lua/pinnacle/grpc/protobuf.lua
+++ b/api/lua/pinnacle/grpc/protobuf.lua
@@ -28,7 +28,7 @@ function protobuf.build_protos()
     }
 
     local xdg_data_home = os.getenv("XDG_DATA_HOME") or (os.getenv("HOME") .. "/.local/share")
-    local xdg_data_dirs = os.getenv("XDG_DATA_DIRS")
+    local xdg_data_dirs = os.getenv("XDG_DATA_DIRS") or "/usr/local/share/:/usr/share/"
 
     ---@type string[]
     local search_dirs = { xdg_data_home }

--- a/snowcap/api/lua/snowcap/grpc/protobuf.lua
+++ b/snowcap/api/lua/snowcap/grpc/protobuf.lua
@@ -20,7 +20,7 @@ function protobuf.build_protos()
     }
 
     local xdg_data_home = os.getenv("XDG_DATA_HOME") or (os.getenv("HOME") .. "/.local/share")
-    local xdg_data_dirs = os.getenv("XDG_DATA_DIRS")
+    local xdg_data_dirs = os.getenv("XDG_DATA_DIRS") or "/usr/local/share/:/usr/share/"
 
     ---@type string[]
     local search_dirs = { xdg_data_home }


### PR DESCRIPTION
problem: pinnacle doesn't run properly if XDG_DATA_DIRS is not set.

cause: According to the spec, when this variable is missing or empty /usr/local/share:/usr/share should be used instead, which is not done here.

solution: Add fallback value in lua APIs.