### PR TITLE
test: fix api::tag::tag_signal_created race-condition

### DIFF
--- a/tests/integration/api/tag.rs
+++ b/tests/integration/api/tag.rs
@@ -583,6 +583,8 @@ fn tag_signal_created() {
             },
         }
 
+        fixture.dispatch_until(|_| tester_cpy.done());
+
         let new_tag = output
             .with_state(|s| {
                 s.tags.iter().find_map(|t| {


### PR DESCRIPTION
problem: The following error may appear in api::tag::tag_signal_created:
```
thread 'api::tag::tag_signal_created' panicked at tests/integration/api/tag.rs:599:9:
assertion failed: storage.contains(&new_tag)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'tokio-runtime-worker' panicked at tests/integration/api/tag.rs:436:47:
called `Result::unwrap()` on an `Err` value: PoisonError { .. }
```

cause: The rust test isn't dispatching until the signal has been received.

solution: Dispatch until the tester `done` callback return true.