### PR TITLE
tests: disable automatic features, and pass them as a cargo test flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ vergen-gitcl = { version = "1.0.5", features = ["rustc", "cargo", "si"] }
 temp-env = "0.3.6"
 tempfile = { workspace = true }
 test-log = { version = "0.2.17", default-features = false, features = ["trace"] }
-pinnacle = { path = ".", features = ["wlcs"], default-features = false }
+pinnacle = { path = ".", default-features = false }
 pinnacle-api = { path = "./api/rust", default-features = false }
 mlua = { version = "0.10.5", features = ["lua54", "send", "macros"] }
 proptest = "1.7.0"

--- a/justfile
+++ b/justfile
@@ -67,7 +67,7 @@ run *args: gen-lua-pb-defs
 
 # Run `cargo test`
 test *args: gen-lua-pb-defs
-    cargo test --no-default-features --all {{args}}
+    cargo test --no-default-features --all --features=testing --exclude wlcs_pinnacle {{args}}
 
 compile-wlcs:
     #!/usr/bin/env bash


### PR DESCRIPTION
The `wlcs` feature flag is applied in the dev-dependencies, but it change the behavior of pinnacle in a way that's breaking the test suite. This feature flag is not really needed, because it's properly defined as a dependency of `wlcs_pinnacle`, which *does* need it.
I've also excluded this package from the workspace tests, since it wasn't doing anything anyway.

The tests failure are due to layout transactions being returned before they are completed, meaning they are never processed properly (https://github.com/pinnacle-comp/pinnacle/blob/0e7cbd68aaf46041196141c3da5d1ced981cad65/src/layout.rs#L240-L246).
 
An alternative to this would be to leave the flag as-is, and add the same "bypass" of the logic in State::update_layout (https://github.com/pinnacle-comp/pinnacle/blob/0e7cbd68aaf46041196141c3da5d1ced981cad65/src/layout.rs#L371). 

I'm not doing that either because it might hide bugs or create new ones.

We might still want to add the "bypass" when running wlcs testsuite and see if it improves the tests results somewhat, but IMO the integration test-suite should run code as close as the release code as possible.

I considered replacing the dev-dependency feature with`testing` flag instead, but since this only add the Dummy output, I removed it altogether, and passed it as a parameter to `cargo test`.