### PR TITLE
Remove dash from the rockspec in nix

### DIFF
--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -79,7 +79,7 @@ let
       ];
     };
     sourceRoot = "${src.name}/api/lua";
-    knownRockspec = ../../api/lua/rockspecs/pinnacle-api-0.2.0-alpha.1-1.rockspec;
+    knownRockspec = ../../api/lua/rockspecs/pinnacle-api-0.2.0alpha.1-1.rockspec;
     propagatedBuildInputs = with lua54Packages; [
       cqueues
       http


### PR DESCRIPTION
Removes dash from the rockspec filename in nix as done in https://github.com/pinnacle-comp/pinnacle/commit/ec7f246af35a1041826829748a0587b4b30eb8ba. 