### PR TITLE
fix(integration): fix syntax error in lua tests

### DIFF
--- a/tests/integration/api/tag.rs
+++ b/tests/integration/api/tag.rs
@@ -485,7 +485,6 @@ impl UserData for TagSignalTester {
     }
 }
 
-#[ignore = "strange lua syntax error after non-breaking update of dependencies"]
 #[test_log::test]
 fn tag_signal_active() {
     for_each_api(|lang| {
@@ -550,7 +549,6 @@ fn tag_signal_active() {
     })
 }
 
-#[ignore = "strange lua syntax error after non-breaking update of dependencies"]
 #[test_log::test]
 fn tag_signal_created() {
     for_each_api(|lang| {
@@ -621,7 +619,6 @@ fn tag_signal_created() {
     });
 }
 
-#[ignore = "strange lua syntax error after non-breaking update of dependencies"]
 #[test_log::test]
 fn tag_signal_removed() {
     for_each_api(|lang| {

--- a/tests/integration/common/fixture.rs
+++ b/tests/integration/common/fixture.rs
@@ -318,7 +318,7 @@ impl Fixture {
         while loop_again {
             tracing::debug!("Flushing transaction and configure");
             for id in client_ids.iter().cloned() {
-                loop_again |= self.client(id).ack_all_window();
+                self.client(id).ack_all_window();
                 self.roundtrip(id);
             }
             self.dispatch();
@@ -363,6 +363,8 @@ macro_rules! spawn_lua_blocking {
                 Pinnacle.run(function()
                     local run = function()
                         $($code)*
+                        ; // Prevent some parsing error because everything is concatenated in a
+                          // string which may or may not end with a '\n'.
                     end
 
                     local success, err = pcall(run)


### PR DESCRIPTION
TL;DR rust 1.92 changed some stuff in macro expansion.

mlua concatenate everything in a single string. Example rom the expanded macro for one of the failing tests :
```
"[...]while not  tester:done() do\nclient.loop:step()\nendend\nlocal success, err = pcall(run)\n"
```

There is usually a \n added between lines, but on the 3 tests, the last token was `end`, and the `\n` got stripped, leaving the `endend` token instead.

I've added a `;` to the fixture so it will work regardless of what happens before, and we're sure the expanded code doesn't mess-up the fixture itself.
