### PR TITLE
fix: properly remove root cache entry when a surface is destroyed

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -403,23 +403,18 @@ impl CompositorHandler for State {
 
         self.pinnacle.dmabuf_hooks.remove(surface);
 
-        let Some(root_surface) = self.pinnacle.root_surface_cache.get(surface) else {
-            return;
-        };
-        let Some(window) = self.pinnacle.window_for_surface(root_surface) else {
-            return;
-        };
-        let Some(output) = window.output(&self.pinnacle) else {
-            return;
-        };
-
-        self.backend.with_renderer(|renderer| {
-            window.capture_snapshot_and_store(
-                renderer,
-                output.current_scale().fractional_scale().into(),
-                1.0,
-            );
-        });
+        if let Some(root_surface) = self.pinnacle.root_surface_cache.get(surface)
+            && let Some(window) = self.pinnacle.window_for_surface(root_surface)
+            && let Some(output) = window.output(&self.pinnacle)
+        {
+            self.backend.with_renderer(|renderer| {
+                window.capture_snapshot_and_store(
+                    renderer,
+                    output.current_scale().fractional_scale().into(),
+                    1.0,
+                );
+            });
+        }
 
         self.pinnacle
             .root_surface_cache


### PR DESCRIPTION
Pinnacle maintains a map of surface <=> root_surface for quick access, but entries weren't always removed. The function that was supposed to remove cache entry could exit early if:
- The surface isn't a root surface
- The surface isn't a window surface (XDG toplevel or XWayland surface)
- The window doesn't have an output. This is due to the WlSurface destroyed callback trying to take a screenshot of window before the surface is gone, and exiting early if it cannot.

The behavior was changed such that the cache entry is always removed when the surface is being destroyed.