### PR TITLE
fix(nix): UWSM session naming and introspection

### DIFF
--- a/nix/modules/nixos/default.nix
+++ b/nix/modules/nixos/default.nix
@@ -1,55 +1,53 @@
-{pkgs, config, lib, ...}:
-let
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}: let
   cfg = config.programs.pinnacle;
-in with lib.options; {
-  options.programs.pinnacle =  {
-    enable = mkEnableOption "pinnacle";
-    package = mkPackageOption pkgs "pinnacle" {
-      default = "pinnacle";
-      example = "pkgs.pinnacle";
-      extraDescription = "package containing the pinnacle server binary";
+in
+  with lib.options; {
+    options.programs.pinnacle = {
+      enable = mkEnableOption "pinnacle";
+      package = mkPackageOption pkgs "pinnacle" {
+        default = "pinnacle";
+        example = "pkgs.pinnacle";
+        extraDescription = "package containing the pinnacle server binary";
+      };
+      xdg-portals.enable = mkEnableOption "xdg-desktop-portal";
+      # if you enable this, make sure to disable the systemd option in the home-manager module
+      withUWSM = mkEnableOption "uwsm";
     };
-    xdg-portals.enable = mkEnableOption "xdg-desktop-portal";
-    # if you enable this, make sure to disable the systemd option in the home-manager module
-    withUWSM = mkEnableOption "uwsm";
-  };
 
-  config = lib.mkIf cfg.enable (lib.mkMerge [
-    {
-      environment.systemPackages = [cfg.package];
-      services.dbus.enable = true;
-      xdg.portal = lib.mkIf cfg.xdg-portals.enable {
-        enable = true;
-        wlr.enable = true;
-        configPackages = [cfg.package];
-        extraPortals = [
-          pkgs.xdg-desktop-portal-wlr
-          pkgs.xdg-desktop-portal-gtk
-          pkgs.gnome-keyring
-        ];
-      };
-    }
-    (let
-      # make sure we launch the version of pinnacle for the current running
-      # generation rather than some other version for a future or past
-      # generation.
-      pinnacle-session = pkgs.writeShellScript "pinnacle-session" ''
-        #!${pkgs.runtimeShell}
-        exec /run/current-system/sw/bin/pinnacle --session
-      '';
-    in lib.mkIf (cfg.withUWSM) {
-      programs.uwsm.enable = true;
-      # Configure UWSM to launch Pinnacle from a display manager like SDDM
-      programs.uwsm.waylandCompositors = {
-        pinnacle = {
-          prettyName = "Pinnacle";
-          comment = "Pinnacle compositor managed by UWSM";
-          binPath = "${pinnacle-session}";
+    config = lib.mkIf cfg.enable (lib.mkMerge [
+      {
+        environment.systemPackages = [cfg.package];
+        services.dbus.enable = true;
+        xdg.portal = lib.mkIf cfg.xdg-portals.enable {
+          enable = true;
+          wlr.enable = true;
+          configPackages = [cfg.package];
+          extraPortals = [
+            pkgs.xdg-desktop-portal-wlr
+            pkgs.xdg-desktop-portal-gtk
+            pkgs.gnome-keyring
+          ];
         };
-      };
-    })
-    (lib.mkIf (!cfg.withUWSM) {
-      services.displayManager.sessionPackages = [cfg.package];
-    })
-  ]);
-}
+      }
+      (lib.mkIf (cfg.withUWSM) {
+        programs.uwsm.enable = true;
+        # Configure UWSM to launch Pinnacle from a display manager like SDDM
+        programs.uwsm.waylandCompositors = {
+          pinnacle = {
+            prettyName = "Pinnacle";
+            comment = "Pinnacle compositor managed by UWSM";
+            binPath = "/run/current-system/sw/bin/pinnacle";
+            extraArgs = ["--session"];
+          };
+        };
+      })
+      (lib.mkIf (!cfg.withUWSM) {
+        services.displayManager.sessionPackages = [cfg.package];
+      })
+    ]);
+  }


### PR DESCRIPTION
this PR addresses a minor annoyance. by using a script in the nix store to pass arguments to pinnacle, we've made the session launched by UWSM possess an incredibly obtuse name. this makes it difficult to e.g. check session status with the UWSM binary or to check session logs in journald. I also just missed that the extra script was unnecessary because there was an `extraArgs` option we could just set instead.