### PR TITLE
snowcap: Add text wrapping

### DIFF
--- a/snowcap/api/lua/snowcap/grpc/defs.lua
+++ b/snowcap/api/lua/snowcap/grpc/defs.lua
@@ -492,6 +492,15 @@ local snowcap_widget_v1_Alignment = {
     ALIGNMENT_END = 3,
 }
 
+---@enum snowcap.widget.v1.Wrapping
+local snowcap_widget_v1_Wrapping = {
+    WRAPPING_UNSPECIFIED = 0,
+    WRAPPING_NONE = 1,
+    WRAPPING_WORD = 2,
+    WRAPPING_GLYPH = 3,
+    WRAPPING_WORD_OR_GLYPH = 4,
+}
+
 ---@enum snowcap.widget.v1.Font.Weight
 local snowcap_widget_v1_Font_Weight = {
     WEIGHT_UNSPECIFIED = 0,
@@ -772,6 +781,7 @@ local snowcap_layer_v1_Layer = {
 ---@field horizontal_alignment snowcap.widget.v1.Alignment?
 ---@field vertical_alignment snowcap.widget.v1.Alignment?
 ---@field style snowcap.widget.v1.Text.Style?
+---@field wrapping snowcap.widget.v1.Wrapping?
 
 ---@class snowcap.widget.v1.Text.Style
 ---@field color snowcap.widget.v1.Color?
@@ -1397,6 +1407,7 @@ snowcap.v0alpha1.Nothing = {}
 snowcap.v1 = {}
 snowcap.v1.Nothing = {}
 snowcap.widget.v1.Alignment = snowcap_widget_v1_Alignment
+snowcap.widget.v1.Wrapping = snowcap_widget_v1_Wrapping
 snowcap.widget.v1.Font.Weight = snowcap_widget_v1_Font_Weight
 snowcap.widget.v1.Font.Stretch = snowcap_widget_v1_Font_Stretch
 snowcap.widget.v1.Font.Style = snowcap_widget_v1_Font_Style

--- a/snowcap/api/lua/snowcap/widget.lua
+++ b/snowcap/api/lua/snowcap/widget.lua
@@ -51,6 +51,7 @@
 ---@field halign snowcap.widget.Alignment?
 ---@field valign snowcap.widget.Alignment?
 ---@field style snowcap.widget.text.Style?
+---@field wrapping snowcap.widget.Wrapping?
 
 ---@class snowcap.widget.text.Style
 ---@field color snowcap.widget.Color?
@@ -541,6 +542,14 @@ local line_height = {
     end,
 }
 
+---@enum snowcap.widget.Wrapping
+local wrapping = {
+    NONE = 1,
+    WORD = 2,
+    GLYPH = 3,
+    WORD_OR_GLYPH = 4,
+}
+
 ---@class snowcap.widget.Color
 ---@field red number?
 ---@field green number?
@@ -651,6 +660,7 @@ local widget = {
         content_fit = content_fit,
     },
     line_height = line_height,
+    wrapping = wrapping,
     mouse = mouse,
 }
 
@@ -666,6 +676,7 @@ local function text_into_api(def)
         height = def.height --[[@as snowcap.widget.v1.Length]],
         vertical_alignment = def.valign,
         horizontal_alignment = def.halign,
+        wrapping = def.wrapping --[[@as snowcap.widget.v1.Wrapping]],
         style = def.style --[[@as snowcap.widget.v1.Text.Style]],
     }
 end

--- a/snowcap/api/protobuf/snowcap/widget/v1/widget.proto
+++ b/snowcap/api/protobuf/snowcap/widget/v1/widget.proto
@@ -128,6 +128,14 @@ message Border {
   optional Radius radius = 3;
 }
 
+enum Wrapping {
+  WRAPPING_UNSPECIFIED = 0;
+  WRAPPING_NONE = 1;
+  WRAPPING_WORD = 2;
+  WRAPPING_GLYPH = 3;
+  WRAPPING_WORD_OR_GLYPH = 4;
+}
+
 message Theme {
   optional Palette palette = 1;
 
@@ -170,6 +178,7 @@ message Text {
   optional Alignment horizontal_alignment = 4;
   optional Alignment vertical_alignment = 5;
   optional Style style = 6;
+  optional Wrapping wrapping = 7;
 
   message Style {
     optional Color color = 1;

--- a/snowcap/api/rust/src/widget.rs
+++ b/snowcap/api/rust/src/widget.rs
@@ -609,6 +609,25 @@ impl From<LineHeight> for widget::v1::LineHeight {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Wrapping {
+    None,
+    Word,
+    Glyph,
+    WordOrGlyph,
+}
+
+impl From<Wrapping> for widget::v1::Wrapping {
+    fn from(value: Wrapping) -> Self {
+        match value {
+            Wrapping::None => widget::v1::Wrapping::None,
+            Wrapping::Word => widget::v1::Wrapping::Word,
+            Wrapping::Glyph => widget::v1::Wrapping::Glyph,
+            Wrapping::WordOrGlyph => widget::v1::Wrapping::WordOrGlyph,
+        }
+    }
+}
+
 // INFO: experimentation
 
 pub trait Program {

--- a/snowcap/api/rust/src/widget/text.rs
+++ b/snowcap/api/rust/src/widget/text.rs
@@ -1,6 +1,6 @@
 use snowcap_api_defs::snowcap::widget;
 
-use super::{Alignment, Color, Length, font::Font};
+use super::{Alignment, Color, Length, Wrapping, font::Font};
 
 /// A text widget definition.
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -10,6 +10,7 @@ pub struct Text {
     pub height: Option<Length>,
     pub horizontal_alignment: Option<Alignment>,
     pub vertical_alignment: Option<Alignment>,
+    pub wrapping: Option<Wrapping>,
     pub style: Option<Style>,
 }
 
@@ -45,6 +46,13 @@ impl Text {
     pub fn vertical_alignment(self, alignment: Alignment) -> Self {
         Self {
             vertical_alignment: Some(alignment),
+            ..self
+        }
+    }
+
+    pub fn wrapping(self, wrapping: Wrapping) -> Self {
+        Self {
+            wrapping: Some(wrapping),
             ..self
         }
     }
@@ -99,13 +107,18 @@ impl From<Text> for widget::v1::Text {
             height: value.height.map(From::from),
             horizontal_alignment: None,
             vertical_alignment: None,
+            wrapping: None,
             style: value.style.map(From::from),
         };
+
         if let Some(horizontal_alignment) = value.horizontal_alignment {
             text.set_horizontal_alignment(horizontal_alignment.into());
         }
         if let Some(vertical_alignment) = value.vertical_alignment {
             text.set_vertical_alignment(vertical_alignment.into());
+        }
+        if let Some(wrapping) = value.wrapping {
+            text.set_wrapping(wrapping.into());
         }
         text
     }

--- a/snowcap/src/api/widget/v1.rs
+++ b/snowcap/src/api/widget/v1.rs
@@ -76,6 +76,7 @@ pub fn widget_def_to_fn(def: WidgetDef) -> Option<ViewFn> {
         widget_def::Widget::Text(text_def) => {
             let horizontal_alignment = text_def.horizontal_alignment();
             let vertical_alignment = text_def.vertical_alignment();
+            let wrapping = text_def.wrapping();
 
             let widget::v1::Text {
                 text,
@@ -84,6 +85,7 @@ pub fn widget_def_to_fn(def: WidgetDef) -> Option<ViewFn> {
                 horizontal_alignment: _,
                 vertical_alignment: _,
                 style,
+                wrapping: _,
             } = text_def;
 
             let f: ViewFn = Box::new(move || {
@@ -127,6 +129,20 @@ pub fn widget_def_to_fn(def: WidgetDef) -> Option<ViewFn> {
                     widget::v1::Alignment::End => {
                         text = text.align_y(iced::alignment::Vertical::Bottom)
                     }
+                }
+
+                let wrapping = match wrapping {
+                    widget::v1::Wrapping::Unspecified => None,
+                    widget::v1::Wrapping::None => Some(iced::widget::text::Wrapping::None),
+                    widget::v1::Wrapping::Word => Some(iced::widget::text::Wrapping::Word),
+                    widget::v1::Wrapping::Glyph => Some(iced::widget::text::Wrapping::Glyph),
+                    widget::v1::Wrapping::WordOrGlyph => {
+                        Some(iced::widget::text::Wrapping::WordOrGlyph)
+                    }
+                };
+
+                if let Some(wrapping) = wrapping {
+                    text = text.wrapping(wrapping);
                 }
 
                 if let Some(font) = style.as_ref().and_then(|s| s.font.clone()) {


### PR DESCRIPTION
Snowcap doesn't provide a way to configure text wrapping and containers can only clip if their size is fixed, meaning containers of variable height but fixed width will allow the text to wrap.

I've had some issue with this when making some menus, where I want the row to resize based on the icon height, but the label to fit on one line. This can be worked around by explicitly setting the row height (not possible in my case), or wrapping the text inside a fix-sized container, but setting the wrapping behavior might be desirable in other context too.
