### PR TITLE
pinnacle: xdg_shell fix window being maximized on startup

### DIFF
--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -414,13 +414,17 @@ impl XdgShellHandler for State {
         {
             match &mut unmapped.state {
                 UnmappedState::WaitingForTags { client_requests } => {
-                    client_requests.layout_mode = Some(FullscreenOrMaximized::Maximized);
+                    client_requests
+                        .layout_mode
+                        .take_if(|mode| matches!(mode, FullscreenOrMaximized::Maximized));
                 }
                 UnmappedState::WaitingForRules {
                     rules: _,
                     client_requests,
                 } => {
-                    client_requests.layout_mode = Some(FullscreenOrMaximized::Maximized);
+                    client_requests
+                        .layout_mode
+                        .take_if(|mode| matches!(mode, FullscreenOrMaximized::Maximized));
                 }
                 UnmappedState::PostInitialConfigure { .. } => {
                     let window = unmapped.window.clone();


### PR DESCRIPTION
Some client (e.g. Nautilus) starts maximized even when the behaviour is explicitly disallowed, and no window rules exists.

The was a copy-pasted introduced error, where calling unmaximized early would set the maximized flag instead of unsetting it.