### PR TITLE
api: provide an error when the output does not exist where to add an tag

### DIFF
--- a/api/lua/pinnacle/grpc/defs.lua
+++ b/api/lua/pinnacle/grpc/defs.lua
@@ -1334,6 +1334,10 @@ local pinnacle_v1_Backend = {
 
 ---@class pinnacle.tag.v1.AddResponse
 ---@field tag_ids integer[]?
+---@field error pinnacle.tag.v1.AddResponse.Error?
+
+---@class pinnacle.tag.v1.AddResponse.Error
+---@field output_does_not_exist google.protobuf.Empty?
 
 ---@class pinnacle.tag.v1.RemoveRequest
 ---@field tag_ids integer[]?
@@ -1613,6 +1617,7 @@ pinnacle.tag.v1.GetRequest = {}
 pinnacle.tag.v1.GetResponse = {}
 pinnacle.tag.v1.AddRequest = {}
 pinnacle.tag.v1.AddResponse = {}
+pinnacle.tag.v1.AddResponse.Error = {}
 pinnacle.tag.v1.RemoveRequest = {}
 pinnacle.tag.v1.MoveToOutputRequest = {}
 pinnacle.tag.v1.MoveToOutputResponse = {}

--- a/api/lua/pinnacle/tag.lua
+++ b/api/lua/pinnacle/tag.lua
@@ -139,6 +139,7 @@ end
 ---@param ... string The names of the new tags.
 ---
 ---@return pinnacle.tag.TagHandle[] tags Handles to the created tags.
+---@return pinnacle.tag.AddError|nil err Error on failure.
 ---
 ---@overload fun(output: pinnacle.output.OutputHandle, tag_names: string[]): pinnacle.tag.TagHandle[]
 function tag.add(output, ...)
@@ -154,10 +155,14 @@ function tag.add(output, ...)
 
     if err then
         log.error(err)
-        return {}
+        return {}, nil
     end
 
     assert(response)
+
+    if response.error and response.error.output_does_not_exist then
+        return {}, { output_does_not_exist = true }
+    end
 
     ---@type pinnacle.tag.TagHandle[]
     local handles = {}
@@ -272,6 +277,9 @@ local signal_name_to_SignalName = {
 ---@field output_does_not_exist boolean?
 ---This operation would cause the provided windows to be on multiple outputs.
 ---@field same_window_on_two_outputs pinnacle.window.WindowHandle[]?
+---@class pinnacle.tag.AddError
+---`true` if the output does not exist.
+---@field output_does_not_exist boolean?
 
 ---Connects to a tag signal.
 ---

--- a/api/protobuf/pinnacle/tag/v1/tag.proto
+++ b/api/protobuf/pinnacle/tag/v1/tag.proto
@@ -15,7 +15,14 @@ message AddRequest {
     repeated string tag_names = 2;
 }
 message AddResponse {
+    message Error {
+        oneof kind {
+            google.protobuf.Empty output_does_not_exist = 1;
+        }
+    }
+
     repeated uint32 tag_ids = 1;
+    optional Error error = 2;
 }
 
 message RemoveRequest {

--- a/api/rust/examples/default_config/main.rs
+++ b/api/rust/examples/default_config/main.rs
@@ -386,7 +386,9 @@ async fn config() {
 
     // Setup all monitors with tags "1" through "9"
     output::for_each_output(move |output| {
-        let mut tags = tag::add(output, tag_names);
+        let Ok(mut tags) = tag::add(output, tag_names) else {
+            return;
+        };
         tags.next().unwrap().set_active(true);
     });
 

--- a/api/rust/src/output.rs
+++ b/api/rust/src/output.rs
@@ -127,7 +127,7 @@ pub async fn get_focused_async() -> Option<OutputHandle> {
 /// # use pinnacle_api::tag;
 /// // Add tags 1-3 to all outputs and set tag "1" to active
 /// output::for_each_output(|op| {
-///     let mut tags = tag::add(op, ["1", "2", "3"]);
+///     let Ok(mut tags) = tag::add(op, ["1", "2", "3"]) else { return };
 ///     tags.next().unwrap().set_active(true);
 /// });
 /// ```

--- a/src/handlers/ext_workspace.rs
+++ b/src/handlers/ext_workspace.rs
@@ -1,3 +1,4 @@
+use crate::api::tag::TagAddError;
 use crate::delegate_ext_workspace;
 use crate::output::OutputName;
 use crate::protocol::ext_workspace::{ExtWorkspaceHandler, ExtWorkspaceManagerState};
@@ -28,7 +29,15 @@ impl ExtWorkspaceHandler for State {
     }
 
     fn add_workspace(&mut self, output: &Output, name: String) {
-        crate::api::tag::add(self, [name.clone()], OutputName(output.name()));
+        match crate::api::tag::add(self, [name.clone()], OutputName(output.name())) {
+            Err(TagAddError::OutputDoesNotExist) => {
+                tracing::warn!(
+                    output_name = output.name(),
+                    "Tried to add tags to output but it doesn't exist",
+                );
+            }
+            Ok(_) => (),
+        }
     }
 }
 

--- a/tests/integration/api/tag.rs
+++ b/tests/integration/api/tag.rs
@@ -115,6 +115,7 @@ fn tag_add() {
                     &pinnacle_api::output::get_focused().unwrap(),
                     ["nubby's", "number", "factory"],
                 );
+                let tags = tags.unwrap();
                 assert_eq!(tags.count(), 3);
             }),
             Lang::Lua => spawn_lua_blocking! {

--- a/wlcs_pinnacle/src/config.rs
+++ b/wlcs_pinnacle/src/config.rs
@@ -4,6 +4,7 @@ mod inner {
     async fn config() {
         pinnacle_api::output::for_each_output(|output| {
             pinnacle_api::tag::add(output, ["1"])
+                .unwrap()
                 .next()
                 .unwrap()
                 .set_active(true);


### PR DESCRIPTION
similar to the error for `move_to_output`