### PR TITLE
chore: fix `cargo doc` warnings

### DIFF
--- a/api/rust/src/layout/generators.rs
+++ b/api/rust/src/layout/generators.rs
@@ -534,9 +534,9 @@ impl LayoutGenerator for Fair {
 /// A [`LayoutGenerator`] that floats windows.
 ///
 /// This works by simply returning an empty layout tree.<br>
-/// Note: the windows are not truly floating, see [`WindowHandle::spilled`] for details.
-///
-/// [`WindowHandle::spilled`]: crate::window::WindowHandle::spilled
+// /// Note: the windows are not truly floating, see [`WindowHandle::spilled`] for details.
+// ///
+// /// [`WindowHandle::spilled`]: crate::window::WindowHandle::spilled
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct Floating {}
 

--- a/snowcap/api/rust/src/surface/layer.rs
+++ b/snowcap/api/rust/src/surface/layer.rs
@@ -118,7 +118,7 @@ impl From<ZLayer> for layer::v1::Layer {
     }
 }
 
-/// The error type for [`Layer::new_widget`].
+/// The error type for [`new_widget`].
 #[derive(thiserror::Error, Debug)]
 pub enum NewLayerError {
     /// Snowcap returned a gRPC error status.

--- a/snowcap/api/rust/src/widget.rs
+++ b/snowcap/api/rust/src/widget.rs
@@ -645,7 +645,7 @@ pub trait Program {
 
     /// Updates this widget program with the received message.
     ///
-    /// If this program has [`Source`]s or child programs, [`Self::Message`]
+    /// If this program has `Source`s or child programs, [`Self::Message`]
     /// should impl `Clone` and the message should be
     /// cloned and passed to all `Source`s and child programs.
     ///

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -252,7 +252,7 @@ impl PendingTransactions {
     }
 }
 
-/// Pending [`UnmappingWindow`][crate::window::UnmappingWindow]s from things like
+/// Pending [`UnmappingWindow`]s from things like
 /// windows closing.
 ///
 /// Pending unmapping windows are picked up by the next requested layout.

--- a/src/render/util.rs
+++ b/src/render/util.rs
@@ -45,7 +45,7 @@ pub struct EncompassingTexture {
 ///
 /// See [`render_to_texture`].
 ///
-/// From https://github.com/YaLTeR/niri/blob/efb39e466b5248eb894745e899de33661493511d/src/render_helpers/mod.rs#L158
+/// From <https://github.com/YaLTeR/niri/blob/efb39e466b5248eb894745e899de33661493511d/src/render_helpers/mod.rs#L158>
 pub fn render_to_encompassing_texture<E: RenderElement<GlesRenderer>>(
     renderer: &mut GlesRenderer,
     elements: impl IntoIterator<Item = E>,
@@ -91,11 +91,11 @@ pub fn render_to_encompassing_texture<E: RenderElement<GlesRenderer>>(
 /// `elements` should have their locations relative to (0, 0), as they will be rendered
 /// to a texture with a rectangle of loc (0, 0) and size `size`. This can be achieved
 /// by wrapping them in a
-/// [`RelocateRenderElement`][smithay::backend::renderer::element::utils::RelocateRenderElement].
+/// [`RelocateRenderElement`].
 ///
 /// Elements outside of the rectangle will be clipped.
 ///
-/// From https://github.com/YaLTeR/niri/blob/efb39e466b5248eb894745e899de33661493511d/src/render_helpers/mod.rs#L180
+/// From <https://github.com/YaLTeR/niri/blob/efb39e466b5248eb894745e899de33661493511d/src/render_helpers/mod.rs#L180>
 pub fn render_to_texture(
     renderer: &mut GlesRenderer,
     elements: impl IntoIterator<Item = impl RenderElement<GlesRenderer>>,
@@ -173,7 +173,7 @@ fn render_elements_to_framebuffer(
 
 /// Renders damage rectangles for the given elements.
 ///
-/// https://github.com/YaLTeR/niri/blob/b351f6ff220560d96a260d8dd3ad794000923481/src/render_helpers/debug.rs#L61
+/// <https://github.com/YaLTeR/niri/blob/b351f6ff220560d96a260d8dd3ad794000923481/src/render_helpers/debug.rs#L61>
 pub fn render_damage_from_elements<E: Element>(
     damage_tracker: &mut OutputDamageTracker,
     elements: &[E],
@@ -209,7 +209,7 @@ pub fn render_damage(
 
 /// Renders opaque region rectangles on top of each element.
 ///
-/// https://github.com/YaLTeR/niri/blob/b351f6ff220560d96a260d8dd3ad794000923481/src/render_helpers/debug.rs#L10
+/// <https://github.com/YaLTeR/niri/blob/b351f6ff220560d96a260d8dd3ad794000923481/src/render_helpers/debug.rs#L10>
 pub fn render_opaque_regions<R: PRenderer>(
     elements: &mut Vec<OutputRenderElement<R>>,
     scale: Scale<f64>,


### PR DESCRIPTION
Note: as `spilled` has been hidden, i decided to hide that part of the documentation too. btw, The link to "spilled" doesnt really make sense to me, so one might rewrite that section in case spilled is ever reactivated.