### PR TITLE
snowcap: Make Program::view return an option

### DIFF
--- a/api/rust/src/experimental.rs
+++ b/api/rust/src/experimental.rs
@@ -22,11 +22,13 @@ pub mod input_grab {
 
         fn update(&mut self, _msg: Self::Message) {}
 
-        fn view(&self) -> snowcap_api::widget::WidgetDef<Self::Message> {
-            Row::new()
-                .width(snowcap_api::widget::Length::Fixed(1.0))
-                .height(snowcap_api::widget::Length::Fixed(1.0))
-                .into()
+        fn view(&self) -> Option<snowcap_api::widget::WidgetDef<Self::Message>> {
+            Some(
+                Row::new()
+                    .width(snowcap_api::widget::Length::Fixed(1.0))
+                    .height(snowcap_api::widget::Length::Fixed(1.0))
+                    .into(),
+            )
         }
     }
 

--- a/api/rust/src/snowcap.rs
+++ b/api/rust/src/snowcap.rs
@@ -57,7 +57,7 @@ impl Program for QuitPrompt {
 
     fn update(&mut self, _msg: Self::Message) {}
 
-    fn view(&self) -> WidgetDef<Self::Message> {
+    fn view(&self) -> Option<WidgetDef<Self::Message>> {
         let widget = Container::new(Column::new_with_children([
             Text::new("Quit Pinnacle?")
                 .style(
@@ -85,7 +85,7 @@ impl Program for QuitPrompt {
             }),
         });
 
-        widget.into()
+        Some(widget.into())
     }
 }
 
@@ -147,7 +147,7 @@ impl Program for BindOverlay {
 
     fn update(&mut self, _msg: Self::Message) {}
 
-    fn view(&self) -> WidgetDef<Self::Message> {
+    fn view(&self) -> Option<WidgetDef<Self::Message>> {
         #[derive(PartialEq, Eq, Hash)]
         struct KeybindRepr {
             mods: Mod,
@@ -395,7 +395,7 @@ impl Program for BindOverlay {
             }),
         });
 
-        widget.into()
+        Some(widget.into())
     }
 }
 
@@ -485,7 +485,7 @@ impl Program for ConfigCrashedMessage {
 
     fn update(&mut self, _msg: Self::Message) {}
 
-    fn view(&self) -> WidgetDef<Self::Message> {
+    fn view(&self) -> Option<WidgetDef<Self::Message>> {
         let widget = Container::new(Column::new_with_children([
             Text::new("Config crashed!")
                 .style(
@@ -534,7 +534,7 @@ impl Program for ConfigCrashedMessage {
             }),
         });
 
-        widget.into()
+        Some(widget.into())
     }
 }
 
@@ -810,7 +810,7 @@ impl Program for FocusBorder {
         }
     }
 
-    fn view(&self) -> WidgetDef<Self::Message> {
+    fn view(&self) -> Option<WidgetDef<Self::Message>> {
         let mut row = Column::new();
 
         if self.include_titlebar {
@@ -993,6 +993,6 @@ impl Program for FocusBorder {
 
         row = row.push(focus_border);
 
-        row.into()
+        Some(row.into())
     }
 }

--- a/snowcap/api/lua/snowcap/decoration.lua
+++ b/snowcap/api/lua/snowcap/decoration.lua
@@ -52,6 +52,10 @@ function decoration.new_widget(args)
     local callbacks = {}
 
     local widget_def = args.program:view()
+    if widget_def == nil then
+        log.error("TopLevel program must return a view.")
+        return nil
+    end
 
     widget._traverse_widget_tree(widget_def, callbacks, widget._collect_callbacks)
 
@@ -120,7 +124,11 @@ function decoration.new_widget(args)
             end
         end
 
+        ---@diagnostic disable-next-line:redefined-local
         local widget_def = args.program:view()
+        if widget_def == nil then
+            error("TopLevel program must return a view")
+        end
         callbacks = {}
 
         widget._traverse_widget_tree(widget_def, callbacks, widget._collect_callbacks)

--- a/snowcap/api/lua/snowcap/layer.lua
+++ b/snowcap/api/lua/snowcap/layer.lua
@@ -97,6 +97,10 @@ function layer.new_widget(args)
     local callbacks = {}
 
     local widget_def = args.program:view()
+    if widget_def == nil then
+        log.error("TopLevel program must return a view.")
+        return nil
+    end
 
     widget._traverse_widget_tree(widget_def, callbacks, widget._collect_callbacks)
 
@@ -165,7 +169,11 @@ function layer.new_widget(args)
             end
         end
 
+        ---@diagnostic disable-next-line:redefined-local
         local widget_def = args.program:view()
+        if widget_def == nil then
+            error("TopLevel program must return a view")
+        end
         callbacks = {}
 
         widget._traverse_widget_tree(widget_def, callbacks, widget._collect_callbacks)

--- a/snowcap/api/lua/snowcap/popup.lua
+++ b/snowcap/api/lua/snowcap/popup.lua
@@ -214,6 +214,10 @@ function popup.new_widget(args)
     local callbacks = {}
 
     local widget_def = args.program:view()
+    if widget_def == nil then
+        log.error("TopLevel program must return a view.")
+        return nil
+    end
 
     widget._traverse_widget_tree(widget_def, callbacks, widget._collect_callbacks)
 
@@ -300,6 +304,9 @@ function popup.new_widget(args)
 
         ---@diagnostic disable-next-line:redefined-local
         local widget_def = args.program:view()
+        if widget_def == nil then
+            error("TopLevel program must return a view")
+        end
         callbacks = {}
 
         widget._traverse_widget_tree(widget_def, callbacks, widget._collect_callbacks)

--- a/snowcap/api/lua/snowcap/widget.lua
+++ b/snowcap/api/lua/snowcap/widget.lua
@@ -4,7 +4,7 @@
 
 ---@class snowcap.widget.Program : snowcap.widget.base.Base
 ---@field update fun(self: self, message: any)
----@field view fun(self: self): snowcap.widget.WidgetDef
+---@field view fun(self: self): snowcap.widget.WidgetDef?
 ---Called when a surface has been created with this program.
 ---
 ---A surface handle is provided to allow the program to manipulate

--- a/snowcap/api/rust/src/surface/decoration.rs
+++ b/snowcap/api/rust/src/surface/decoration.rs
@@ -65,6 +65,10 @@ pub enum NewDecorationError {
     /// Snowcap returned a gRPC error status.
     #[error("gRPC error: `{0}`")]
     GrpcStatus(#[from] tonic::Status),
+
+    /// [`Program::view()`] returned None.
+    #[error("Toplevel Program must return a WidgetDef")]
+    EmptyView,
 }
 
 /// Create a new widget.
@@ -81,7 +85,7 @@ where
 {
     let mut callbacks = HashMap::<WidgetId, WidgetMessage<Msg>>::new();
 
-    let widget_def = program.view();
+    let widget_def = program.view().ok_or(NewDecorationError::EmptyView)?;
 
     widget_def.collect_messages(&mut callbacks, WidgetDef::message_collector);
 
@@ -170,7 +174,9 @@ where
                 else => break,
             };
 
-            let widget_def = program.view();
+            let widget_def = program
+                .view()
+                .expect("Toplevel program must return a WidgetDef");
 
             callbacks.clear();
 

--- a/snowcap/api/rust/src/surface/layer.rs
+++ b/snowcap/api/rust/src/surface/layer.rs
@@ -124,6 +124,10 @@ pub enum NewLayerError {
     /// Snowcap returned a gRPC error status.
     #[error("gRPC error: `{0}`")]
     GrpcStatus(#[from] tonic::Status),
+
+    /// [`Program::view()`] returned None.
+    #[error("Toplevel Program must return a WidgetDef")]
+    EmptyView,
 }
 
 /// The error type for [`LayerHandle::update`] and set_* functions.
@@ -148,7 +152,7 @@ where
 {
     let mut callbacks = HashMap::<WidgetId, WidgetMessage<Msg>>::new();
 
-    let widget_def = program.view();
+    let widget_def = program.view().ok_or(NewLayerError::EmptyView)?;
 
     widget_def.collect_messages(&mut callbacks, WidgetDef::message_collector);
 
@@ -240,7 +244,9 @@ where
                 else => break,
             };
 
-            let widget_def = program.view();
+            let widget_def = program
+                .view()
+                .expect("Toplevel program must return a WidgetDef");
 
             callbacks.clear();
 

--- a/snowcap/api/rust/src/surface/popup.rs
+++ b/snowcap/api/rust/src/surface/popup.rs
@@ -148,6 +148,10 @@ pub enum NewPopupError {
     /// Snowcap returned a gRPC error status.
     #[error("gRPC error: `{0}`")]
     GrpcStatus(#[from] tonic::Status),
+
+    /// [`Program::view()`] returned None.
+    #[error("Toplevel Program must return a WidgetDef")]
+    EmptyView,
 }
 
 /// The error type for [`PopupHandle::update`].
@@ -176,7 +180,7 @@ where
 {
     let mut callbacks = HashMap::<WidgetId, WidgetMessage<Msg>>::new();
 
-    let widget_def = program.view();
+    let widget_def = program.view().ok_or(NewPopupError::EmptyView)?;
 
     widget_def.collect_messages(&mut callbacks, WidgetDef::message_collector);
 
@@ -273,7 +277,9 @@ where
                 else => break,
             };
 
-            let widget_def = program.view();
+            let widget_def = program
+                .view()
+                .expect("Toplevel program must return a WidgetDef");
 
             callbacks.clear();
 

--- a/snowcap/api/rust/src/widget.rs
+++ b/snowcap/api/rust/src/widget.rs
@@ -653,7 +653,7 @@ pub trait Program {
     fn update(&mut self, msg: Self::Message);
 
     /// Creates a widget definition for display by Snowcap.
-    fn view(&self) -> WidgetDef<Self::Message>;
+    fn view(&self) -> Option<WidgetDef<Self::Message>>;
 
     /// Called when a surface has been created with this program.
     ///
@@ -711,7 +711,7 @@ impl<Msg> Program for Box<dyn Program<Message = Msg>> {
         (**self).update(msg);
     }
 
-    fn view(&self) -> WidgetDef<Self::Message> {
+    fn view(&self) -> Option<WidgetDef<Self::Message>> {
         (**self).view()
     }
 
@@ -738,7 +738,7 @@ impl<Msg> Program for Box<dyn Program<Message = Msg> + Send> {
         (**self).update(msg);
     }
 
-    fn view(&self) -> WidgetDef<Self::Message> {
+    fn view(&self) -> Option<WidgetDef<Self::Message>> {
         (**self).view()
     }
 
@@ -765,7 +765,7 @@ impl<Msg> Program for Box<dyn Program<Message = Msg> + Send + Sync> {
         (**self).update(msg);
     }
 
-    fn view(&self) -> WidgetDef<Self::Message> {
+    fn view(&self) -> Option<WidgetDef<Self::Message>> {
         (**self).view()
     }
 

--- a/snowcap/api/rust/src/widget/text_input.rs
+++ b/snowcap/api/rust/src/widget/text_input.rs
@@ -73,14 +73,14 @@
 //!         }
 //!     }
 //!
-//!     fn view(&self) -> widget::WidgetDef<Self::Message> {
+//!     fn view(&self) -> Option<widget::WidgetDef<Self::Message>> {
 //!         let widget = TextInput::new("placeholder:", &self.input_value.clone())
 //!             .id(Self::INPUT_ID)
 //!             .on_input(Message::ContentChanged)
 //!             .on_submit(Message::Submit)
 //!             .width(Length::Fixed(220.0));
 //!
-//!         widget.into()
+//!         Some(widget.into())
 //!     }
 //! }
 //! ```


### PR DESCRIPTION
Snowcap `Program` are now meant to both act as top-level handles and as composable fragment of the widget tree. Having the `view()` function return an option allow parent widget to filter-out empty views, instead of having the child needlessly return an empty container.

If this cannot be merged as-is due to breaking the API, we could solve this using a sub-trait `SubProgram`, with a blanket implementation for `Program` and a `try_view` function instead of the view function. We'd also need to change `Program::register_child` to take `SubProgram` instead of `Program`.

However, I don't know if I like having that distinction, so I changed the `Program` trait instead.

Fixes: #427 