### PR TITLE
Snowcap: Add derive macro for Signal and Universal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,6 +4566,7 @@ dependencies = [
  "futures",
  "hyper-util",
  "snowcap-api-defs",
+ "snowcap-derive",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -4584,6 +4585,14 @@ dependencies = [
  "tonic",
  "tonic-build",
  "walkdir",
+]
+
+[[package]]
+name = "snowcap-derive"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ passfd = "0.1.6"
 pinnacle-api-defs = { path = "./pinnacle-api-defs" }
 prost = "0.13.5"
 snowcap-api-defs = { path = "./snowcap/snowcap-api-defs" }
+snowcap-derive = { path = "./snowcap/snowcap-derive" }
 snowcap-protocols = { path = "./snowcap/snowcap-protocols" }
 tempfile = "3.25.0"
 thiserror = "2.0.18"

--- a/snowcap/api/rust/Cargo.toml
+++ b/snowcap/api/rust/Cargo.toml
@@ -11,6 +11,7 @@ from_variants = "1.0.2"
 futures = { workspace = true }
 hyper-util = { workspace = true }
 snowcap-api-defs = { workspace = true }
+snowcap-derive = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/snowcap/api/rust/src/signal.rs
+++ b/snowcap/api/rust/src/signal.rs
@@ -1,5 +1,7 @@
 //! Widget signals.
 
+pub use snowcap_derive::Signal;
+
 use std::{
     any::{Any, TypeId},
     collections::HashMap,

--- a/snowcap/api/rust/src/widget/message.rs
+++ b/snowcap/api/rust/src/widget/message.rs
@@ -1,5 +1,7 @@
 use std::any::Any;
 
+pub use snowcap_derive::Universal;
+
 /// A universal message type.
 ///
 /// This is a suitable catch-all message for all built-in widget programs.

--- a/snowcap/api/rust/src/widget/operation.rs
+++ b/snowcap/api/rust/src/widget/operation.rs
@@ -46,7 +46,7 @@ use snowcap_api_defs::snowcap::operation;
 use crate::signal::Signal;
 
 /// Update widgets' internal state.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Signal, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum Operation {
     Focusable(focusable::Focusable),
@@ -209,5 +209,3 @@ impl From<Operation> for operation::v1::operation::Target {
         }
     }
 }
-
-impl Signal for Operation {}

--- a/snowcap/api/rust/src/widget/signal.rs
+++ b/snowcap/api/rust/src/widget/signal.rs
@@ -1,19 +1,15 @@
 use crate::signal::Signal;
 
 /// Notifies that a redraw is needed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Signal, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RedrawNeeded;
 
-impl Signal for RedrawNeeded {}
-
 /// Request the surface to close itself.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Signal, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RequestClose;
 
-impl Signal for RequestClose {}
-
 /// Emits a message that will update widgets.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Signal, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Message<Msg>(pub Msg);
 
 impl<Msg> Message<Msg> {
@@ -34,10 +30,6 @@ impl<Msg> From<Msg> for Message<Msg> {
     }
 }
 
-impl<Msg: Clone + 'static> Signal for Message<Msg> {}
-
 /// Notifies that a widget closed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Signal, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Closed;
-
-impl Signal for Closed {}

--- a/snowcap/snowcap-derive/Cargo.toml
+++ b/snowcap/snowcap-derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "snowcap-derive"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+syn = "2.0"
+quote = "1.0"
+
+[lib]
+proc-macro = true

--- a/snowcap/snowcap-derive/src/lib.rs
+++ b/snowcap/snowcap-derive/src/lib.rs
@@ -1,0 +1,38 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, parse_macro_input};
+
+mod signal;
+
+/// Signal derive macro.
+#[proc_macro_derive(Signal)]
+pub fn derive_signal(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = input.ident;
+
+    let generics = signal::add_trait_bounds(input.generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let expanded = quote! {
+        impl #impl_generics Signal for #name #ty_generics #where_clause {}
+    };
+
+    expanded.into()
+}
+
+/// [`Universal`] derive macro.
+#[proc_macro_derive(Universal)]
+pub fn derive_universal(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = input.ident;
+
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let expanded = quote! {
+        impl #impl_generics Universal for #name #ty_generics #where_clause {}
+    };
+
+    expanded.into()
+}

--- a/snowcap/snowcap-derive/src/signal.rs
+++ b/snowcap/snowcap-derive/src/signal.rs
@@ -1,0 +1,12 @@
+use syn::{GenericParam, Generics, parse_quote};
+
+pub fn add_trait_bounds(mut generics: Generics) -> Generics {
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            type_param.bounds.push(parse_quote!(Clone));
+            type_param.bounds.push(parse_quote!('static));
+        }
+    }
+
+    generics
+}


### PR DESCRIPTION
This PR adds derive macro for `Signal` and `Universal`.

The `Signal` macro add bounds `Clone + 'static` automatically on generic types. I did not implement any validation/pruning yet, meaning deriving signal for :
```rust
struct<Msg: Clone> AAA {
   [...]
}
```

Will lead to the following code being generated:
```rust
impl<Msg: Clone + Clone + 'static> Signal for AAA<Msg> {}
```

Which I don't quite like.

Draft until #430 is merged.