### PR TITLE
Fix clippy 0.1.97

### DIFF
--- a/src/api/layout/v1.rs
+++ b/src/api/layout/v1.rs
@@ -113,7 +113,7 @@ impl TryFrom<layout::v1::LayoutNode> for crate::layout::tree::LayoutNode {
                     top: taffy::LengthPercentageAuto::length(gaps.top),
                     bottom: taffy::LengthPercentageAuto::length(gaps.bottom),
                 })
-                .unwrap_or(taffy::Rect::length(0.0)),
+                .unwrap_or(taffy::Rect::length(0.0_f32)),
             ..Default::default()
         };
 

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -156,7 +156,7 @@ impl LayoutTree {
         if children.is_empty() {
             let mut new_node_style = tree.style(node).unwrap().clone();
             let prev_margin = new_node_style.margin;
-            new_node_style.margin = taffy::Rect::length(0.0);
+            new_node_style.margin = taffy::Rect::length(0.0_f32);
             tree.set_style(node, new_node_style).unwrap();
 
             let leaf_child = tree

--- a/src/util/treediff/zs.rs
+++ b/src/util/treediff/zs.rs
@@ -179,16 +179,14 @@ impl<'a, T> ZsTree<'a, T> {
             kr: Vec::new(),
         };
 
-        let mut idx = 1;
         let mut tmp_data = HashMap::new();
-        for n in tree.traverse_post_order() {
+        for (idx, n) in (1..).zip(tree.traverse_post_order()) {
             tmp_data.insert(n, idx);
             this.set_i_tree(idx, n);
             this.set_lld(idx, *tmp_data.get(&get_first_leaf(n)).unwrap());
             if n.children().next().is_none() {
                 this.leaf_count += 1;
             }
-            idx += 1;
         }
 
         this.set_keyroots();


### PR DESCRIPTION
Fixes the following new warning/clippy lint:

Latest rust environment added new warning for float -> f32 coercion as this will become a hard error in the future.
https://github.com/rust-lang/rust/issues/154024

Clippy now complains if an explicit index is used with iterator instead of `enumerate` for 0-based counter),or `(n..).zip` if the counter isn't 0-based.  (clippy::explicit_counter_loop)