### PR TITLE
Nix: set package's meta.mainProgram

### DIFF
--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -73,7 +73,10 @@ let
   };
 in
 rustPlatform.buildRustPackage (finalAttrs: {
-  inherit meta version;
+  inherit version;
+  meta = meta // {
+    mainProgram = "pinnacle";
+  };
 
   pname = "pinnacle-server";
   src = ../..;


### PR DESCRIPTION
To avoid:

```
evaluation warning: getExe: Package "pinnacle-server-0.2.3" does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
```
