### PR TITLE
nixos/pinnacle: add protobuf files to system like home-manager

### DIFF
--- a/nix/modules/nixos/default.nix
+++ b/nix/modules/nixos/default.nix
@@ -21,7 +21,17 @@ in
 
     config = lib.mkIf cfg.enable (lib.mkMerge [
       {
-        environment.systemPackages = [cfg.package];
+        environment.systemPackages = [
+          cfg.package
+          pkgs.protobuf
+          cfg.package.lua-client-api
+        ];
+        environment.pathsToLink = [
+          # For /run/current-system/sw/share/pinnacle protobuf files - for
+          # pinnacle to be able to launch with a non-default config out of the
+          # box.
+          "/share/pinnacle"
+        ];
         services.dbus.enable = true;
         xdg.portal = lib.mkIf cfg.xdg-portals.enable {
           enable = true;


### PR DESCRIPTION
Hello,

While trying to setup pinnacle as a NixOS service, using the service defined in `flake.nix`, I found this to be useful. Without it, a Lua configuration setup failed to launch with the error `could not find protobuf definitions directory`.
