### PR TITLE
Update Cargo.toml to use HTTPS for pinnacle-api

### DIFF
--- a/api/rust/examples/default_config/for_copying/Cargo.toml
+++ b/api/rust/examples/default_config/for_copying/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-pinnacle-api = { git = "http://github.com/pinnacle-comp/pinnacle", default-features = false, tag = "v0.2.0" }
+pinnacle-api = { git = "https://github.com/pinnacle-comp/pinnacle", default-features = false, tag = "v0.2.0" }
 
 [features]
 default = ["snowcap"]


### PR DESCRIPTION
Needed to change the URL to `https://`, otherwise `cargo build` on a freshly new `pinnacle config gen` won't properly fetch the repo