### PR TITLE
Nix: filter src robustly with gitignore.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,6 +39,26 @@
         "type": "github"
       }
     },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762808025,
+        "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1772479524,
@@ -59,6 +79,7 @@
       "inputs": {
         "fenix": "fenix",
         "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,15 +11,47 @@
     };
 
     flake-utils.url = "github:numtide/flake-utils";
+    gitignore = {
+      url = "github:hercules-ci/gitignore.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
     {
+      self,
       nixpkgs,
       flake-utils,
+      gitignore,
       fenix,
       ...
     }:
+    let 
+      vergen_env = {
+        VERGEN_GIT_DIRTY = nixpkgs.lib.optionalString (self ? rev) "true";
+        VERGEN_GIT_SHA = if (self ? rev) then self.rev else "<unavailable>(Nix)";
+        VERGEN_GIT_BRANCH = "<unavailable>(Nix)";
+        VERGEN_GIT_COMMIT_MESSAGE = "<unavailable>(Nix)";
+      };
+      src = nixpkgs.lib.cleanSourceWith {
+        # Ignore many files that gitignoreSource doesn't ignore, see:
+        # https://github.com/hercules-ci/gitignore.nix/issues/9#issuecomment-635458762
+        filter =
+          path: type:
+          !(builtins.any (r: (builtins.match r (baseNameOf path)) != null) [
+            # Nix files
+            "flake.nix"
+            "flake.lock"
+            "nix"
+            # CI files
+            ".github"
+            # Docs
+            ".*.md"
+            "wiki"
+          ]);
+        src = gitignore.lib.gitignoreSource ./.;
+      };
+    in
     (flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
       system:
       let
@@ -27,7 +59,9 @@
           inherit system;
           overlays = [
             (final: prev: {
-              pinnacle = prev.callPackage ./nix/packages/default.nix { };
+              pinnacle = prev.callPackage ./nix/packages/default.nix {
+                inherit vergen_env src;
+              };
             })
           ];
         };
@@ -118,7 +152,9 @@
     ))
     // {
       overlays.default = final: prev: {
-        pinnacle = prev.callPackage ./nix/packages/default.nix { };
+        pinnacle = prev.callPackage ./nix/packages/default.nix {
+          inherit vergen_env src;
+        };
       };
 
       nixosModules = {

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,4 +1,6 @@
 {
+  src,
+  vergen_env ? {},
   rustPlatform,
   lib,
   pkg-config,
@@ -39,18 +41,10 @@ let
   version = "0.2.3";
 
   lua-client-api = lua54Packages.buildLuarocksPackage rec {
-    inherit meta version;
+    inherit src meta version;
     pname = "pinnacle-client-api";
-    src = lib.fileset.toSource {
-      root = ../..;
-      # we should probably filter out parts of the repo that aren't relevant but this at least works
-      fileset = lib.fileset.unions [
-        ../../api
-        ../../snowcap
-      ];
-    };
     sourceRoot = "${src.name}/api/lua";
-    knownRockspec = ../../api/lua/rockspecs/pinnacle-api-0.2.2-1.rockspec;
+    knownRockspec = "rockspecs/pinnacle-api-0.2.2-1.rockspec";
     propagatedBuildInputs = with lua54Packages; [
       cqueues
       http
@@ -73,15 +67,15 @@ let
   };
 in
 rustPlatform.buildRustPackage (finalAttrs: {
-  inherit version;
+  inherit src version;
   meta = meta // {
     mainProgram = "pinnacle";
   };
+  env = vergen_env;
 
   pname = "pinnacle-server";
-  src = ../..;
   cargoLock = {
-    lockFile = "${../..}/Cargo.lock";
+    lockFile = "${src}/Cargo.lock";
     # as we're not in-tree in nixpkgs right now, we don't benefit from the public nix subsituters.
     # consequently, we can neither provide a single static `cargoHash` nor a set of hashes for just
     # the dependencies fetched via git (these can change since cargo doesn't pin the git revision).


### PR DESCRIPTION
I noticed this can be useful when playing with Nix files. The lack of sufficient `VERGEN_*` environment variables might tilt you towards not accepting it, but maybe I can think of different solutions - maybe without `gitignore.nix`.
