### PR TITLE
fix(nix): compat53 version compat

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1772521798,
-        "narHash": "sha256-N69u6BZTfCyCsqyc1Qv/qvqkGkTCO6peGInKae51r/E=",
+        "lastModified": 1786005881,
+        "narHash": "sha256-Bj3VKIiwX1daO4vOIyAM507A65J0aaRSctc87kiT7H4=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "9ba6d89cd7cb4d2b94953d56bea1d46e08aa53bd",
+        "rev": "a7c3ef79859bf024cdc865a0ed8f14a4e3f31099",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772479524,
-        "narHash": "sha256-u7nCaNiMjqvKpE+uZz9hE7pgXXTmm5yvdtFaqzSzUQI=",
+        "lastModified": 1786022024,
+        "narHash": "sha256-4NW/sBCUhMR+tx32bo901ddhFllDjJW4eR9qwg8O6+A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4215e62dc2cd3bc705b0a423b9719ff6be378a43",
+        "rev": "71651ac56b73b99a3c9fb758c98978f3a5e0840f",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1772438613,
-        "narHash": "sha256-D+yZsIKkfRABreaY0Q+jsCtLB5WlnBKpZ1+Sk5qjuRQ=",
+        "lastModified": 1785960076,
+        "narHash": "sha256-+Xej+akyhjZIFnsEIZLO3c6YNvlnKB3rFMzsprQCyDM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "3c4ae110c7682cfc723f9f0adb49c19e2e7a0893",
+        "rev": "cf3b451f47c01d76989425d1ace3f1cba70f1fdb",
         "type": "github"
       },
       "original": {

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -59,6 +59,11 @@ let
       luaposix
     ];
 
+    postConfigure = ''
+      substituteInPlace "$rockspecFilename" \
+        --replace-fail '"compat53 ~> 0.14"' '"compat53 >= 0.13, < 0.16,"'
+    '';
+
     postInstall = ''
       mkdir -p $out/share/pinnacle/protobuf/pinnacle
       cp -rL --no-preserve ownership,mode ../../api/protobuf/pinnacle $out/share/pinnacle/protobuf

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -13,7 +13,7 @@
   mesa,
   xwayland,
   libinput,
-  libdisplay-info,
+  libdisplay-info_0_3,
   git,
   libgbm,
   rustc,
@@ -104,7 +104,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libinput
     mesa
     xwayland
-    libdisplay-info
+    libdisplay-info_0_3
     libgbm
     lua5_4
 

--- a/nix/packages/pinnacle-config.nix
+++ b/nix/packages/pinnacle-config.nix
@@ -6,26 +6,37 @@
   libxkbcommon,
   libinput,
   lua5_4,
-  libdisplay-info,
+  libdisplay-info_0_3,
   libgbm,
 }:
-{src, ...}@args:
-rustPlatform.buildRustPackage ((builtins.removeAttrs args ["cargoLock" "nativeBuildInputs" "buildInputs"]) // {
-  PINNACLE_PROTOBUF_API_DEFS = ../../api/protobuf;
-  PINNACLE_PROTOBUF_SNOWCAP_API_DEFS = ../../snowcap/api/protobuf;
+{ src, ... }@args:
+rustPlatform.buildRustPackage (
+  (builtins.removeAttrs args [
+    "cargoLock"
+    "nativeBuildInputs"
+    "buildInputs"
+  ])
+  // {
+    PINNACLE_PROTOBUF_API_DEFS = ../../api/protobuf;
+    PINNACLE_PROTOBUF_SNOWCAP_API_DEFS = ../../snowcap/api/protobuf;
 
-  nativeBuildInputs = (args.nativeBuildInputs or []) ++ [protobuf pkg-config];
-  buildInputs = (args.buildInputs or []) ++ [
-    seatd.dev
-    libxkbcommon
-    libinput
-    lua5_4
-    libdisplay-info
-    libgbm
-  ];
+    nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
+      protobuf
+      pkg-config
+    ];
+    buildInputs = (args.buildInputs or [ ]) ++ [
+      seatd.dev
+      libxkbcommon
+      libinput
+      lua5_4
+      libdisplay-info_0_3
+      libgbm
+    ];
 
-  cargoLock = {
-    lockFile = src + /Cargo.lock;
-    allowBuiltinFetchGit = true;
-  } // (args.cargoLock or {});
-})
+    cargoLock = {
+      lockFile = src + /Cargo.lock;
+      allowBuiltinFetchGit = true;
+    }
+    // (args.cargoLock or { });
+  }
+)


### PR DESCRIPTION
nixpkgs updated the version of compat53 to 0.15. this updates the package here [to match upstream](https://github.com/NixOS/nixpkgs/commit/9a2b9bf6becff18e47374d99cf4d674800a07a7f) so the package works with both pre-compat53 update and post-.